### PR TITLE
Fedora Build

### DIFF
--- a/software/Makefile
+++ b/software/Makefile
@@ -1,3 +1,7 @@
+TARGET=$(shell awk 'NR==1{print $$1}' /etc/issue)
+
+default: $(TARGET)
+
 all: infnoise infnoise-v1
 
 infnoise: infnoise.c infnoise.h healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
@@ -5,6 +9,9 @@ infnoise: infnoise.c infnoise.h healthcheck.c writeentropy.c Keccak/KeccakF-1600
 
 infnoise-v1: infnoise.c infnoise.h healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
 	gcc -Wall -std=c99 -O3 -DVERSION1 -I Keccak -o infnoise-v1 infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi -lm -lrt
+
+Fedora: infnoise.c infnoise.h healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
+	gcc -Wall -std=c99 -O3 -I Keccak -DDIST=Fedora -o infnoise infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi1 -lm -lrt
 
 clean:
 	rm -f infnoise infnoise-v1

--- a/software/Makefile
+++ b/software/Makefile
@@ -11,7 +11,7 @@ endif
 
 infnoise-v1: infnoise.c infnoise.h healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
 ifeq ($(TARGET),Fedora)
-	gcc -Wall -std=c99 -O3 -DVERSION1 -I Keccak -o infnoise-v1 infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi1 -lm -lrt
+	gcc -Wall -std=c99 -O3 -DVERSION1 -I Keccak -DDIST=Fedora -o infnoise-v1 infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi1 -lm -lrt
 else
 	gcc -Wall -std=c99 -O3 -DVERSION1 -I Keccak -o infnoise-v1 infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi -lm -lrt
 endif

--- a/software/Makefile
+++ b/software/Makefile
@@ -1,17 +1,20 @@
 TARGET=$(shell awk 'NR==1{print $$1}' /etc/issue)
 
-default: $(TARGET)
-
 all: infnoise infnoise-v1
 
 infnoise: infnoise.c infnoise.h healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
+ifeq ($(TARGET),Fedora)
+	gcc -Wall -std=c99 -O3 -I Keccak -DDIST=Fedora -o infnoise infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi1 -lm -lrt
+else
 	gcc -Wall -std=c99 -O3 -I Keccak -o infnoise infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi -lm -lrt
+endif
 
 infnoise-v1: infnoise.c infnoise.h healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
+ifeq ($(TARGET),Fedora)
+	gcc -Wall -std=c99 -O3 -DVERSION1 -I Keccak -o infnoise-v1 infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi1 -lm -lrt
+else
 	gcc -Wall -std=c99 -O3 -DVERSION1 -I Keccak -o infnoise-v1 infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi -lm -lrt
-
-Fedora: infnoise.c infnoise.h healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
-	gcc -Wall -std=c99 -O3 -I Keccak -DDIST=Fedora -o infnoise infnoise.c healthcheck.c writeentropy.c Keccak/KeccakF-1600-reference.c -lftdi1 -lm -lrt
+endif
 
 clean:
 	rm -f infnoise infnoise-v1

--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -9,7 +9,13 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include <ftdi.h>
+
+#if DIST == Fedora
+	#include <libftdi1/ftdi.h>
+#else
+	#include <ftdi.h>
+#endif
+
 #include "infnoise.h"
 #include "KeccakF-1600-interface.h"
 

--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -3,6 +3,7 @@
 // Required to include clock_gettime
 #define _POSIX_C_SOURCE 200809L
 
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
My attempt to build cleanly on Fedora.  I wouldn't expect b4d8fe0 to interfere on other distributions as it should be available on those as well.

I prefer 0b26b03 over 2bce640 as 0b26b03 doesn't assume you want to build on Fedora when building on other distributions.