### PR TITLE
Fix for Bug #10 (-lfdti or -lfdti1)

### DIFF
--- a/software/Makefile
+++ b/software/Makefile
@@ -1,9 +1,16 @@
 CFLAGS = -Wall -std=c99 -O3 -I Keccak -I /usr/include/libftdi1
 
+@_=	$(shell ld -lftdi 2> /dev/null)
+ifeq ($$?, 0)
+	FTDI=	-lftdi
+else
+	FTDI=	-lftdi1
+endif
+
 all: infnoise
 
 infnoise: infnoise.c infnoise.h healthcheck.c writeentropy.c daemon.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
-	$(CC) $(CFLAGS) -o infnoise infnoise.c healthcheck.c writeentropy.c daemon.c Keccak/KeccakF-1600-reference.c -lftdi -lm -lrt
+	$(CC) $(CFLAGS) -o infnoise infnoise.c healthcheck.c writeentropy.c daemon.c Keccak/KeccakF-1600-reference.c $(FTDI) -lm -lrt
 
 clean:
 	$(RM) infnoise


### PR DESCRIPTION
Hello,

On Funtoo (Gentoo-based meta-distribution), I have the same issue as does @maztaim on Fedora (see Bug #10): we need ld to use -lfdti1 instead of -lfdti.

While @maztaim proposed to check the distribution name (PR #5 ), I'm using the fact that ld return 0 if there is no error loading a lib but no input file and 1 if the lib isn't found.

Regards.