### PR TITLE
Improved un-/replug behaviour with systemd/udev rule

### DIFF
--- a/software/75-infnoise.rules
+++ b/software/75-infnoise.rules
@@ -1,1 +1,2 @@
-ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", TAG+="systemd", ENV{SYSTEMD_WANTS}="infnoise.service"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", SYMLINK+="infnoise" 
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015" ,TAG+="systemd", ENV{SYSTEMD_WANTS}="infnoise.service"

--- a/software/infnoise.service
+++ b/software/infnoise.service
@@ -2,14 +2,14 @@
 Description=Wayward Geek InfNoise TRNG driver
 
 [Service]
-Type=simple
+Type=forking
 WorkingDirectory=/tmp
-ExecStart=/usr/local/sbin/infnoise --dev-random
+ExecStart=/usr/sbin/infnoise --dev-random --daemon --pidfile /var/run/infnoise.pid
 User=root
 Group=root
-Restart=always
-RestartSec=1min
-Restart=on-failure
+Restart=never
+BindsTo=dev-infnoise.device
+After=dev-infnoise.device
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This changes behavior of the service as it doesn't auto-restart anymore, until the device is plugged in.