### PR TITLE
Improved install & postinstall targets

### DIFF
--- a/software/Makefile
+++ b/software/Makefile
@@ -1,3 +1,5 @@
+PREFIX = $(DESTDIR)/usr/local
+
 CFLAGS = -Wall -Wextra -Werror -std=c99 -O3 -I Keccak -I /usr/include/libftdi1
 
 FOUND = $(shell ldconfig -p | grep --silent libftdi.so && echo found)
@@ -16,11 +18,11 @@ clean:
 	$(RM) infnoise
 
 install:
-	install -m 0755 infnoise $(DESTDIR)/sbin/
-	install -d $(DESTDIR)/lib/udev/rules.d/
-	install -m 0644 75-infnoise.rules $(DESTDIR)/lib/udev/rules.d/
-	install -d $(DESTDIR)/lib/systemd/system
-	install -m 0644 infnoise.service $(DESTDIR)/lib/systemd/system
+	install -m 0755 infnoise $(PREFIX)/sbin/
+	install -d $(PREFIX)/lib/udev/rules.d/
+	install -m 0644 75-infnoise.rules $(PREFIX)/lib/udev/rules.d/
+	install -d $(PREFIX)/lib/systemd/system
+	install -m 0644 infnoise.service $(PREFIX)/lib/systemd/system
 
 postinstall:
 	systemctl restart systemd-udevd

--- a/software/Makefile
+++ b/software/Makefile
@@ -18,6 +18,7 @@ clean:
 	$(RM) infnoise
 
 install:
+        install -d $(PREFIX)/sbin             
 	install -m 0755 infnoise $(PREFIX)/sbin/
 	install -d $(PREFIX)/lib/udev/rules.d/
 	install -m 0644 75-infnoise.rules $(PREFIX)/lib/udev/rules.d/
@@ -27,4 +28,3 @@ install:
 postinstall:
 	systemctl restart systemd-udevd
 	systemctl enable infnoise
-

--- a/software/Makefile
+++ b/software/Makefile
@@ -7,10 +7,6 @@ else
 	FTDI=	-lftdi1
 endif
 
-install:
-	cp infnoise /usr/local/sbin
-	pidof systemd > /dev/null && cp infnoise.service /lib/systemd/system
-
 all: infnoise
 
 infnoise: infnoise.c infnoise.h healthcheck.c writeentropy.c daemon.c Keccak/KeccakF-1600-reference.c Keccak/brg_endian.h
@@ -18,3 +14,14 @@ infnoise: infnoise.c infnoise.h healthcheck.c writeentropy.c daemon.c Keccak/Kec
 
 clean:
 	$(RM) infnoise
+
+install:
+	install -m 0755 infnoise $(DESTDIR)/sbin/
+	install -d $(DESTDIR)/lib/udev/rules.d/
+	install -m 0644 75-infnoise.rules $(DESTDIR)/lib/udev/rules.d/
+	install -d $(DESTDIR)/lib/systemd/system
+	install -m 0644 infnoise.service $(DESTDIR)/lib/systemd/system
+
+postinstall:
+	systemctl restart systemd-udevd
+	systemctl enable infnoise

--- a/software/Makefile
+++ b/software/Makefile
@@ -18,7 +18,7 @@ clean:
 	$(RM) infnoise
 
 install:
-        install -d $(PREFIX)/sbin             
+	install -d $(PREFIX)/sbin
 	install -m 0755 infnoise $(PREFIX)/sbin/
 	install -d $(PREFIX)/lib/udev/rules.d/
 	install -m 0644 75-infnoise.rules $(PREFIX)/lib/udev/rules.d/


### PR DESCRIPTION
Use DESTDIR for installation path, added postinstall section to enable services.