### PR TITLE
Update infnoise.service

### DIFF
--- a/software/infnoise.service
+++ b/software/infnoise.service
@@ -7,7 +7,7 @@ WorkingDirectory=/tmp
 ExecStart=/usr/local/sbin/infnoise --dev-random --daemon --pidfile /var/run/infnoise.pid
 User=root
 Group=root
-Restart=never
+Restart=no
 BindsTo=dev-infnoise.device
 After=dev-infnoise.device
 


### PR DESCRIPTION
'sysctl status infnoise' produces 'Failed to parse service restart specifier, ignoring: never'. Option 'never' is not recognized. Changed to 'no'.