### PR TITLE
Update infnoise.c

### DIFF
--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -3,8 +3,8 @@
 // Required to include clock_gettime
 #define _POSIX_C_SOURCE 200809L
 
-#define VENDOR_ID 0x0403
-#define PRODUCT_ID 0x6015
+#define VENDORID 0x0403
+#define PRODUCTID 0x6015
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -129,7 +129,7 @@ static bool listUSBDevices(struct ftdi_context *ftdic) {
     int i=0;
 
     // search devices
-    int rc = ftdi_usb_find_all(ftdic, &devlist, VENDOR_ID, PRODUCT_ID);
+    int rc = ftdi_usb_find_all(ftdic, &devlist, VENDORID, PRODUCTID);
     if (rc < 0) {
         if(!isSuperUser()) {
             fprintf(stderr, "Can't find Infinite Noise Multiplier.  Try running as super user?\n");
@@ -158,7 +158,7 @@ static bool initializeUSB(struct ftdi_context *ftdic, char **message, char *seri
 
     // search devices
     int rc = 0;
-    if ((rc = ftdi_usb_find_all(ftdic, &devlist, VENDOR_ID, PRODUCT_ID)) < 0) {
+    if ((rc = ftdi_usb_find_all(ftdic, &devlist, VENDORID, PRODUCTID)) < 0) {
         *message = "Can't find Infinite Noise Multiplier\n";
         return false;
     }
@@ -170,7 +170,7 @@ static bool initializeUSB(struct ftdi_context *ftdic, char **message, char *seri
             if (rc >= 1) {
 		fprintf(stderr,"Multiple Infnoise TRNGs found. No serial specfified, so using the first one");
             }
-            if (ftdi_usb_open(ftdic, VENDOR_ID, PRODUCT_ID) < 0) {
+            if (ftdi_usb_open(ftdic, VENDORID, PRODUCTID) < 0) {
                 if(!isSuperUser()) {
                     *message = "Can't open Infinite Noise Multiplier. Try running as super user?\n";
                 } else {
@@ -180,7 +180,7 @@ static bool initializeUSB(struct ftdi_context *ftdic, char **message, char *seri
 	    }
         } else {
             // serial specified
-            rc = ftdi_usb_open_desc(ftdic, VENDOR_ID, PRODUCT_ID, "FT240X USB FIFO", serial);
+            rc = ftdi_usb_open_desc(ftdic, VENDORID, PRODUCTID, "FT240X USB FIFO", serial);
             if (rc < 0) {
                 if(!isSuperUser()) {
                     *message = "Can't find Infinite Noise Multiplier. Try running as super user?\n";


### PR DESCRIPTION
On Manjaro 17.0.2 64b, ' make' results in:

infnoise.c:6:19: error: expected identifier before numeric constant
 #define VENDOR_ID 0x0403
                   ^
/usr/include/libftdi1/ftdi.h:279:5: note: in expansion of macro ‘VENDOR_ID’
     VENDOR_ID          = 0,
     ^~~~~~~~~
make: *** [Makefile:15: infnoise] Error 1

After I changed 'VENDOR_ID' and 'PRODUCT_ID' to 'VENDORID' and 'PRODUCTID' in infnoise.c, it compiles without a problem.