### PR TITLE
Fix compiler-warning from GCC 6.4

### DIFF
--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -3,9 +3,6 @@
 // Required to include clock_gettime
 #define _POSIX_C_SOURCE 200809L
 
-#define VENDOR_ID 0x0403
-#define PRODUCT_ID 0x6015
-
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -15,6 +12,9 @@
 #include <ftdi.h>
 #include "infnoise.h"
 #include "KeccakF-1600-interface.h"
+
+#define VEND_ID 0x0403
+#define PROD_ID 0x6015
 
 // Extract the INM output from the data received.  Basically, either COMP1 or COMP2
 // changes, not both, so alternate reading bits from them.  We get 1 INM bit of output
@@ -129,7 +129,7 @@ static bool listUSBDevices(struct ftdi_context *ftdic) {
     int i=0;
 
     // search devices
-    int rc = ftdi_usb_find_all(ftdic, &devlist, VENDOR_ID, PRODUCT_ID);
+    int rc = ftdi_usb_find_all(ftdic, &devlist, VEND_ID, PROD_ID);
     if (rc < 0) {
         if(!isSuperUser()) {
             fprintf(stderr, "Can't find Infinite Noise Multiplier.  Try running as super user?\n");
@@ -158,7 +158,7 @@ static bool initializeUSB(struct ftdi_context *ftdic, char **message, char *seri
 
     // search devices
     int rc = 0;
-    if ((rc = ftdi_usb_find_all(ftdic, &devlist, VENDOR_ID, PRODUCT_ID)) < 0) {
+    if ((rc = ftdi_usb_find_all(ftdic, &devlist, VEND_ID, PROD_ID)) < 0) {
         *message = "Can't find Infinite Noise Multiplier\n";
         return false;
     }
@@ -170,7 +170,7 @@ static bool initializeUSB(struct ftdi_context *ftdic, char **message, char *seri
             if (rc >= 1) {
 		fprintf(stderr,"Multiple Infnoise TRNGs found. No serial specfified, so using the first one");
             }
-            if (ftdi_usb_open(ftdic, VENDOR_ID, PRODUCT_ID) < 0) {
+            if (ftdi_usb_open(ftdic, VEND_ID, PROD_ID) < 0) {
                 if(!isSuperUser()) {
                     *message = "Can't open Infinite Noise Multiplier. Try running as super user?\n";
                 } else {
@@ -180,7 +180,7 @@ static bool initializeUSB(struct ftdi_context *ftdic, char **message, char *seri
 	    }
         } else {
             // serial specified
-            rc = ftdi_usb_open_desc(ftdic, VENDOR_ID, PRODUCT_ID, "FT240X USB FIFO", serial);
+            rc = ftdi_usb_open_desc(ftdic, VEND_ID, PROD_ID, "FT240X USB FIFO", serial);
             if (rc < 0) {
                 if(!isSuperUser()) {
                     *message = "Can't find Infinite Noise Multiplier. Try running as super user?\n";


### PR DESCRIPTION
Redefining #defines gives a warning. That is trated like an error
with current compiler options.