### PR TITLE
OpenRC script: Fix dependencies

### DIFF
--- a/software/scripts/infnoise.openrc
+++ b/software/scripts/infnoise.openrc
@@ -3,7 +3,8 @@
 PIDFILE=/run/infnoise.pid
 
 depend() {
-	need udev-settle
+	need udev-settle localmount
+	provide trng	# Support need/use trng in other scripts
 }
 
 start() {


### PR DESCRIPTION
Wait for filesystems to be mounted. This makes sure there is a
place to write the PID-file.
Provide "trng" for other scripts to depend on.