### PR TITLE
Introduce struct for parsed options

### DIFF
--- a/software/README
+++ b/software/README
@@ -73,7 +73,9 @@ Options are:
     --raw - do not whiten the output
     --multiplier <value> - write 256 bits * value for each 512 bits written to the Keccak sponge
     --no-output - do not write random output data
-    --daemon - run in the background. Output should be redirected to a file or the options should be used with --dev-random
+    --daemon - run in the background. Output should be redirected to a file or
+    the options should be used with --dev-random. To reduce CPU-usage addition
+    af entropy is only forced after a minute rather than a second.
     --pidfile <filename> - write the process ID to a file. If --daemon is used, it is the ID of the background process.
     --serial <serial> - use Infinite Noise TRNG/FT240 with the given serial number (see --list-devices)
     --list-devices - list available devices

--- a/software/daemon.c
+++ b/software/daemon.c
@@ -24,11 +24,11 @@ static bool writePid(int32_t pid, char *fileName) {
     return true;
 }
 
-void startDaemon(bool daemon, bool pidFile, char *fileName) {
-	if(!daemon) {
+void startDaemon(struct opt_struct* opts) {
+	if(!opts->daemon) {
 		// No backgrounding, optionslly write current PID
-		if(pidFile) {
-			writePid(getpid(), fileName);
+		if(opts->pidFileName != NULL) {
+			writePid(getpid(), opts->pidFileName);
 		}
 		return;
 	}
@@ -38,8 +38,8 @@ void startDaemon(bool daemon, bool pidFile, char *fileName) {
 		exit(1);
 	} else if(pid > 0) {
 		// Parent
-		if(pidFile) {
-			if(!writePid(pid, fileName)) {
+		if(opts->pidFileName != NULL) {
+			if(!writePid(pid, opts->pidFileName)) {
 				exit(1);
 			}
 		}

--- a/software/healthcheck.c
+++ b/software/healthcheck.c
@@ -91,11 +91,11 @@ static void resetStats(void) {
 // Initialize the health check.  N is the number of bits used to predict the next bit.
 // At least 8 bits must be used, and no more than 30.  In general, we should use bits
 // large enough so that INM output will be uncorrelated with bits N samples back in time.
-bool inmHealthCheckStart(uint8_t N, double K, bool debug) {
+bool inmHealthCheckStart(uint8_t N, double K, struct opt_struct *opts) {
     if(N < 1u || N > 30u) {
         return false;
     }
-    inmDebug = debug;
+    inmDebug = opts->debug;
     inmNumBitsOfEntropy = 0u;
     inmCurrentProbability = 1.0;
     inmK = K;

--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -56,7 +56,7 @@ static void outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, struc
             exit(1);
         }
     } else {
-        inmWaitForPoolToHaveRoom();
+        inmWaitForPoolToHaveRoom(opts);
         inmWriteEntropyToPool(bytes, length, entropy);
     }
 }

--- a/software/infnoise.h
+++ b/software/infnoise.h
@@ -54,7 +54,7 @@ void inmClearEntropyLevel(void);
 bool inmEntropyOnTarget(uint32_t entropy, uint32_t bits);
 void inmWriteEntropyStart(uint32_t bufLen, struct opt_struct *opts);
 void inmWriteEntropyToPool(uint8_t *bytes, uint32_t length, uint32_t entropy);
-void inmWaitForPoolToHaveRoom(void);
+void inmWaitForPoolToHaveRoom(struct opt_struct *opts);
 void inmDumpStats(void);
 void startDaemon(struct opt_struct *opts);
 bool isSuperUser(void);

--- a/software/infnoise.h
+++ b/software/infnoise.h
@@ -30,7 +30,20 @@
 // All data bus bits of the FT240X are outputs, except COMP1 and COMP2
 #define MASK (0xffu & ~(1u << COMP1) & ~(1u << COMP2))
 
-bool inmHealthCheckStart(uint8_t N, double K, bool debug);
+// Structure for parsed command line options
+struct opt_struct {
+	uint32_t outputMultiplier; // We output all the entropy when outputMultiplier == 0
+	bool daemon;		// Run as daemon?
+	bool debug;		// Print debugging info?
+	bool devRandom;		// Feed /dev/random?
+	bool noOutput;		// Supress output?
+	bool listDevices;	// List possible USB-devices?
+	bool raw;		// No whitening?
+	char *pidFileName;	// Name of optional PID-file
+	char *serial;		// Name of selected device
+};
+
+bool inmHealthCheckStart(uint8_t N, double K, struct opt_struct *opts);
 void inmHealthCheckStop(void);
 bool inmHealthCheckAddBit(bool evenBit, bool oddBit, bool even);
 bool inmHealthCheckOkToUseData(void);
@@ -39,11 +52,11 @@ double inmHealthCheckEstimateEntropyPerBit(void);
 uint32_t inmGetEntropyLevel(void);
 void inmClearEntropyLevel(void);
 bool inmEntropyOnTarget(uint32_t entropy, uint32_t bits);
-void inmWriteEntropyStart(uint32_t bufLen, bool debug);
+void inmWriteEntropyStart(uint32_t bufLen, struct opt_struct *opts);
 void inmWriteEntropyToPool(uint8_t *bytes, uint32_t length, uint32_t entropy);
 void inmWaitForPoolToHaveRoom(void);
 void inmDumpStats(void);
-void startDaemon(bool daemon, bool pidFile, char *fileName);
+void startDaemon(struct opt_struct *opts);
 bool isSuperUser(void);
 
 extern double inmK, inmExpectedEntropyPerBit;

--- a/software/writeentropy.c
+++ b/software/writeentropy.c
@@ -61,7 +61,7 @@ void inmWriteEntropyStart(uint32_t bufLen, struct opt_struct* opts) {
 }
 
 // Block until either the entropy pool has room, or 1 second has passed.
-void inmWaitForPoolToHaveRoom(void) {
+void inmWaitForPoolToHaveRoom(struct opt_struct *opts) {
     int ent_count;
     struct pollfd pfd = {
         .fd = inmDevRandomFD,
@@ -72,6 +72,8 @@ void inmWaitForPoolToHaveRoom(void) {
         return;
     }
     timeout_msec = 1000u; // One second
+    if (opts->daemon)
+	timeout_msec *= 60u; // Do not poll aggressively when in the background
     poll(&pfd, 1, timeout_msec);
 }
 

--- a/software/writeentropy.c
+++ b/software/writeentropy.c
@@ -40,9 +40,9 @@ static uint32_t readNumberFromFile(char *fileName) {
 }
 
 // Open /dev/random
-void inmWriteEntropyStart(uint32_t bufLen, bool debug) {
+void inmWriteEntropyStart(uint32_t bufLen, struct opt_struct* opts) {
     inmBufLen = bufLen;
-    inmDebug = debug;
+    inmDebug = opts->debug;
     //inmDevRandomFD = open("/dev/random", O_WRONLY);
     inmDevRandomFD = open("/dev/random", O_RDWR);
     if(inmDevRandomFD < 0) {


### PR DESCRIPTION
This contains two commits. The first adds a structure opt_struct for parsed options. A pointer to the structure replaces some arguments to function calls. This makes the calls simpler, but the overall code size does not shrink.

The second commit reduces the CPU-usage by increasing the poll timeout if the --daemon option is used.  This change means that infnoise does not show up in top(1) on my system.