### PR TITLE
Always se long poll() timeout

### DIFF
--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -53,7 +53,7 @@ static void outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, struc
             exit(1);
         }
     } else {
-        inmWaitForPoolToHaveRoom(opts);
+        inmWaitForPoolToHaveRoom();
         inmWriteEntropyToPool(bytes, length, entropy);
     }
 }

--- a/software/infnoise.h
+++ b/software/infnoise.h
@@ -54,7 +54,7 @@ void inmClearEntropyLevel(void);
 bool inmEntropyOnTarget(uint32_t entropy, uint32_t bits);
 void inmWriteEntropyStart(uint32_t bufLen, struct opt_struct *opts);
 void inmWriteEntropyToPool(uint8_t *bytes, uint32_t length, uint32_t entropy);
-void inmWaitForPoolToHaveRoom(struct opt_struct *opts);
+void inmWaitForPoolToHaveRoom(void);
 void inmDumpStats(void);
 void startDaemon(struct opt_struct *opts);
 bool isSuperUser(void);

--- a/software/writeentropy.c
+++ b/software/writeentropy.c
@@ -60,21 +60,17 @@ void inmWriteEntropyStart(uint32_t bufLen, struct opt_struct* opts) {
     }
 }
 
-// Block until either the entropy pool has room, or 1 second has passed.
-void inmWaitForPoolToHaveRoom(struct opt_struct *opts) {
+// Block until either the entropy pool has room, or 1 minute has passed.
+void inmWaitForPoolToHaveRoom() {
     int ent_count;
     struct pollfd pfd = {
         .fd = inmDevRandomFD,
         .events = POLLOUT,
     };
-    int64_t timeout_msec;
     if (ioctl(inmDevRandomFD, RNDGETENTCNT, &ent_count) == 0 && (uint32_t)ent_count < inmFillWatermark) {
         return;
     }
-    timeout_msec = 1000u; // One second
-    if (opts->daemon)
-	timeout_msec *= 60u; // Do not poll aggressively when in the background
-    poll(&pfd, 1, timeout_msec);
+    poll(&pfd, 1, 1000u * 60u); // One minute
 }
 
 // Add the bytes to the entropy pool.  This can be unwhitenened, but the estimated bits of


### PR DESCRIPTION
Many init systems do their own backgrounding so use long timeout
unconditionally. Change suggested by Manuel Domke.