### PR TITLE
Update Makefile

### DIFF
--- a/software/Makefile
+++ b/software/Makefile
@@ -10,7 +10,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c99 -O3 -I Keccak -I /usr/include/libftdi1 \
  -DGIT_DATE=\"$(GIT_DATE)\"\
  -DBUILD_DATE=\"$(BUILD_DATE)\"
 
-FTDI := $(shell libftdi-config --libs)
+FTDI := $(shell libftdi1-config --libs)
 
 all: infnoise
 


### PR DESCRIPTION
In Manjaro libftdi-config is not available, libftdi1-config is.
After this 'make install' works, but 'systemctl start infnoise' waits and after some time results in:
infnoise.service: Job infnoise.service/start failed with result 'dependency'.
dev-infnoise.device: Job dev-infnoise.device/start failed with result 'timeout'.

I have no solution for this, except going to a previous build.

B.t.w. I closed this because I thought I was too fast, you were still working on it.
