### PR TITLE
fix --multiplier mode

### DIFF
--- a/software/build-scripts/PKGBUILD.arch
+++ b/software/build-scripts/PKGBUILD.arch
@@ -10,7 +10,7 @@ md5sums=('SKIP')
 install='INSTALL'
 build() {
   cd "${srcdir}/infnoise/software/"
-  make
+  make -f Makefile.linux
 }
 
 package() {

--- a/software/build-scripts/build.sh
+++ b/software/build-scripts/build.sh
@@ -5,8 +5,8 @@ VERSION=`git --no-pager describe --tags --always`
 
 PATH=$PATH:/sbin/
 
-make clean
-make
+make -f Makefile.linux clean
+make -f Makefile.linux
 
 rm -rf build
 mkdir -p build/DEBIAN
@@ -40,7 +40,7 @@ rm -rf build
 cd tools
 mkdir -p build/usr/bin/
 
-make
+make -f Makefile.linux
 
 cp passgen build/usr/bin/infnoise-passgen
 cp dice build/usr/bin/infnoise-dice
@@ -67,7 +67,7 @@ rm -rf build
 mkdir -p build/usr/lib
 mkdir -p build/usr/include
 
-make libinfnoise.so
+make -f Makefile.linux libinfnoise.so
 
 cp libinfnoise.so build/usr/lib/
 cp libinfnoise.h build/usr/include

--- a/software/build-scripts/infnoise-tools.spec
+++ b/software/build-scripts/infnoise-tools.spec
@@ -18,7 +18,7 @@ tar -xzf ../SOURCES/infnoise.tar.gz
 
 %build
 cd tools
-make
+make -f Makefile.linux
 
 %install
 #make DESTDIR=$RPM_BUILD_ROOT install

--- a/software/build-scripts/infnoise.spec
+++ b/software/build-scripts/infnoise.spec
@@ -17,7 +17,7 @@ BuildRoot:      %{_tmppath}/%{name}-root
 tar -xzf ../SOURCES/infnoise.tar.gz
 
 %build
-make
+make -f Makefile.linux
 
 %install
 #make DESTDIR=$RPM_BUILD_ROOT install


### PR DESCRIPTION
fixed bug introduced with libinfnoise (#51): the output array in multiplier mode wasn't initialized properly.