### PR TITLE
Made output to buffer or stdout contingent on output buffer being NULL.

### DIFF
--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -220,8 +220,10 @@ int main(int argc, char **argv) {
     // endless loop
     uint64_t totalBytesWritten = 0u;
     while(true) {
+	uint8_t buffer[BUFLEN];
         uint64_t prevTotalBytesWritten = totalBytesWritten;
-        totalBytesWritten += readData_private(&ftdic, NULL, &message, &errorFlag, opts.noOutput, opts.raw, opts.outputMultiplier, opts.devRandom); // calling libinfnoise's private readData method
+        totalBytesWritten += readData_private(&ftdic, opts.noOutput ? buffer : NULL, &message, &errorFlag,
+	    opts.noOutput, opts.raw, opts.outputMultiplier, opts.devRandom); // calling libinfnoise's private readData method
 
         if (errorFlag) {
             fprintf(stderr, "Error: %s\n", message);

--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
 	uint8_t buffer[BUFLEN];
         uint64_t prevTotalBytesWritten = totalBytesWritten;
         totalBytesWritten += readData_private(&ftdic, opts.noOutput ? buffer : NULL, &message, &errorFlag,
-	    opts.noOutput, opts.raw, opts.outputMultiplier, opts.devRandom); // calling libinfnoise's private readData method
+	    opts.raw, opts.outputMultiplier, opts.devRandom); // calling libinfnoise's private readData method
 
         if (errorFlag) {
             fprintf(stderr, "Error: %s\n", message);

--- a/software/libinfnoise.h
+++ b/software/libinfnoise.h
@@ -17,6 +17,8 @@ bool listUSBDevices(struct ftdi_context *ftdic, char **message);
 
 bool initInfnoise(struct ftdi_context *ftdic, char *serial, char **message, bool keccak, bool debug);
 
+// If |result| is NULL, then output is to stdout.
 uint32_t readRawData(struct ftdi_context *ftdic, uint8_t *result, char **message, bool *errorFlag);
 
+// If |result| is NULL, then output is to stdout.
 uint32_t readData(struct ftdi_context *ftdic, uint8_t *result, char **message, bool *errorFlag, uint32_t outputMultiplier);

--- a/software/libinfnoise_private.h
+++ b/software/libinfnoise_private.h
@@ -64,6 +64,6 @@ uint32_t extractBytes(uint8_t *bytes, uint8_t *inBuf, char **message, bool *erro
 
 bool outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, bool writeDevRandom, char **message);
 uint32_t processBytes(uint8_t *bytes, uint8_t *result, uint32_t entropy, bool raw,
-                      bool writeDevRandom, uint32_t outputMultiplier, bool noOutput, char **message, bool *errorFlag);
+                      bool writeDevRandom, uint32_t outputMultiplier, char **message, bool *errorFlag);
 
-uint32_t readData_private(struct ftdi_context *ftdic, uint8_t *result, char **message, bool *errorFlag, bool noOutput, bool raw, uint32_t outputMultiplier, bool devRandom);
+uint32_t readData_private(struct ftdi_context *ftdic, uint8_t *result, char **message, bool *errorFlag, bool raw, uint32_t outputMultiplier, bool devRandom);


### PR DESCRIPTION
The interface in libinfnoise.h did not allow for turning off output to stdout, so instead of adding another noOutput parameter, I deprecated it, and made output to stdout dependent on the output bufffer (result) being NULL.  I could not find any instances where output to stdout and to a buffer are a "thing", which makes sense, so it seems like a safe change.

It is now possible to use libinfnoise in "silent" mode by specifying a result buffer.
