### PR TITLE
Archlinux build script fix

### DIFF
--- a/software/build-scripts/build-archlinux.sh
+++ b/software/build-scripts/build-archlinux.sh
@@ -24,8 +24,8 @@ done
 mkdir -p x86_64
 cd x86_64
 
-cp ../build-scripts/PKGBUILD.arch PKGBUILD
-cp ../build-scripts/INSTALL.arch INSTALL
+cp ../PKGBUILD.arch PKGBUILD
+cp ../INSTALL.arch INSTALL
 
 sed -i "s|.*source.*=.*(.*).*|source=('git+$GITREPO')|g" PKGBUILD
 #echo "pkgver=$VERSION.$PKGREL" >> PKGBUILD


### PR DESCRIPTION
script changes into x86_64. Afterwards it tries to copy the *.arch templates that are now under ../ not ../build-scripts.