### PR TITLE
Recursive listUSBdev.()

### DIFF
--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -60,7 +60,7 @@ static struct option longopts[] = {
         {NULL,           0,                 NULL, 0}};
 
 // Write the bytes to either stdout, or /dev/random.
-bool outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, bool writeDevRandom, char **message) {
+bool outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, bool writeDevRandom, const char **message) {
     if (!writeDevRandom) {
         if (fwrite(bytes, 1, length, stdout) != length) {
             *message = "Unable to write output from Infinite Noise Multiplier";

--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -16,8 +16,6 @@
 #include <string.h>
 #include <signal.h>
 #include <time.h>
-#include <sys/types.h>
-#include <ftdi.h> // requires <sys/types.h>
 #include <getopt.h>
 #include "infnoise.h"
 #include "libinfnoise.h"
@@ -223,19 +221,19 @@ int main(int argc, char **argv) {
     }
 
     if (opts.listDevices) {
-        devlist_node devlist = listUSBDevices(&context.message);
+        infnoise_devlist_node_t* devlist = listUSBDevices(&context.message);
         if (devlist == NULL) {
             fprintf(stderr, "Error: %s\n", context.message);
             return 1;
         }
-        devlist_node curdev;
-        for (curdev = devlist; curdev != NULL; ) {
+        infnoise_devlist_node_t* curdev;
+        int id = 0;
+        for (curdev = devlist; curdev != NULL; id++) {
             printf("ID: %i, Manufacturer: %s, Description: %s, Serial: %s\n",
-                   curdev->id, curdev->manufacturer,
-                   curdev->description, curdev->serial);
+                   id, curdev->manufacturer, curdev->description, curdev->serial);
 
             // cleanup:
-            devlist_node olddev = curdev;
+            infnoise_devlist_node_t* olddev = curdev;
             curdev = curdev->next;
             free(olddev);
         }

--- a/software/infnoise.h
+++ b/software/infnoise.h
@@ -6,7 +6,6 @@
 #else
 #include <linux/limits.h>
 #endif
-#include <ftdi.h>
 
 // Structure for parsed command line options
 struct opt_struct {

--- a/software/libinfnoise.c
+++ b/software/libinfnoise.c
@@ -253,7 +253,8 @@ infnoise_devlist_node_t* listUSBDevices(char **message) {
 
     infnoise_devlist_node_t* retlist = NULL;
     struct ftdi_device_list *devlist = NULL;
-    if (ftdi_usb_find_all(&ftdic, &devlist, INFNOISE_VENDOR_ID, INFNOISE_PRODUCT_ID) < 0) {
+    if (ftdi_usb_find_all(&ftdic, &devlist, INFNOISE_VENDOR_ID, INFNOISE_PRODUCT_ID) < 0
+        || devlist == NULL) {
         if (!isSuperUser()) {
             *message = "Can't find Infinite Noise Multiplier.  Try running as super user?";
         } else {

--- a/software/libinfnoise.c
+++ b/software/libinfnoise.c
@@ -73,6 +73,7 @@ bool initInfnoise(struct infnoise_context *context, char *serial, bool keccak, b
 void deinitInfnoise(struct infnoise_context *context)
 {
     inmHealthCheckStop();
+    ftdi_usb_close(&context->ftdic);
     ftdi_deinit(&context->ftdic);
 }
 

--- a/software/libinfnoise.c
+++ b/software/libinfnoise.c
@@ -214,11 +214,7 @@ infnoise_devlist_node_t* inf_get_devstrings(struct ftdi_context* ftdic,
                                       cur->description, sizeof(cur->description),
                                       cur->serial, sizeof(cur->serial));
         if (rc < 0) {
-            if (!isSuperUser()) {
-                *message = "Can't find Infinite Noise Multiplier. Try running as super user?";
-            } else {
-                sprintf(*message, "ftdi_usb_get_strings failed: %d (%s)", rc, ftdi_get_error_string(ftdic));
-            }
+            sprintf(*message, "ftdi_usb_get_strings failed: %d (%s)", rc, ftdi_get_error_string(ftdic));
             free( cur );
             return NULL;
         }

--- a/software/libinfnoise.c
+++ b/software/libinfnoise.c
@@ -93,7 +93,7 @@ void prepareOutputBuffer() {
 // changes, not both, so alternate reading bits from them.  We get 1 INM bit of output
 // per byte read.  Feed bits from the INM to the health checker.  Return the expected
 // bits of entropy.
-uint32_t extractBytes(uint8_t *bytes, uint32_t length, uint8_t *inBuf, char **message, bool *errorFlag) {
+uint32_t extractBytes(uint8_t *bytes, uint32_t length, uint8_t *inBuf, const char **message, bool *errorFlag) {
     inmClearEntropyLevel();
     uint32_t i;
     for (i = 0u; i < length; i++) {
@@ -202,7 +202,7 @@ bool isSuperUser(void) {
 // let's do it recursive, because if sth. fails we can easily wipe the malloc()
 infnoise_devlist_node_t* inf_get_devstrings(struct ftdi_context* ftdic,
                                             struct ftdi_device_list* curdev,
-                                            char** message,
+                                            const char** message,
                                             infnoise_devlist_node_t* bgn,
                                             infnoise_devlist_node_t* end) {
     if( curdev != NULL ) {
@@ -214,7 +214,7 @@ infnoise_devlist_node_t* inf_get_devstrings(struct ftdi_context* ftdic,
                                       cur->description, sizeof(cur->description),
                                       cur->serial, sizeof(cur->serial));
         if (rc < 0) {
-            sprintf(*message, "ftdi_usb_get_strings failed: %d (%s)", rc, ftdi_get_error_string(ftdic));
+            *message = ftdi_get_error_string(ftdic);
             free( cur );
             return NULL;
         }
@@ -240,7 +240,7 @@ infnoise_devlist_node_t* inf_get_devstrings(struct ftdi_context* ftdic,
 
 
 // Return a list of all infinite noise multipliers found.
-infnoise_devlist_node_t* listUSBDevices(char **message) {
+infnoise_devlist_node_t* listUSBDevices(const char **message) {
     struct ftdi_context ftdic;
     if(ftdi_init(&ftdic) < 0) {
         *message = "Failed to init";
@@ -267,7 +267,7 @@ infnoise_devlist_node_t* listUSBDevices(char **message) {
 }
 
 // Initialize the Infinite Noise Multiplier USB interface.
-bool initializeUSB(struct ftdi_context *ftdic, char **message, char *serial) {
+bool initializeUSB(struct ftdi_context *ftdic, const char **message, char *serial) {
     ftdi_init(ftdic);
     struct ftdi_device_list *devlist;
 

--- a/software/libinfnoise.h
+++ b/software/libinfnoise.h
@@ -25,15 +25,13 @@ struct infnoise_context {
     uint32_t bytesWritten;
 };
 
-struct infnoise_devlist_node {
-    uint8_t id;
+typedef struct _infnoise_devlist_node_t infnoise_devlist_node_t;
+struct _infnoise_devlist_node_t {
     char manufacturer[128];
     char description[128];
     char serial[128];
-    struct infnoise_devlist_node *next;
+    infnoise_devlist_node_t *next;
 };
-
-typedef struct infnoise_devlist_node *devlist_node;
 
 /*
  * returns a struct of infnoise_devlist_node listing all connected FTDI FT240 devices by their USB descriptors
@@ -43,7 +41,7 @@ typedef struct infnoise_devlist_node *devlist_node;
  *
  *  returns: NULL when none found or infnoise_devlist_node
  */
-devlist_node listUSBDevices(char **message);
+infnoise_devlist_node_t* listUSBDevices(char **message);
 
 /*
  * initialize the Infinite Noise TRNG - must be called once before readData() works

--- a/software/libinfnoise.h
+++ b/software/libinfnoise.h
@@ -16,7 +16,7 @@
 struct infnoise_context {
     struct ftdi_context ftdic;
     uint32_t entropyThisTime;
-    char *message;
+    const char *message;
     bool errorFlag;
     //uint8_t keccakState[KeccakPermutationSizeInBytes];
 
@@ -41,7 +41,7 @@ struct _infnoise_devlist_node_t {
  *
  *  returns: NULL when none found or infnoise_devlist_node
  */
-infnoise_devlist_node_t* listUSBDevices(char **message);
+infnoise_devlist_node_t* listUSBDevices(const char **message);
 
 /*
  * initialize the Infinite Noise TRNG - must be called once before readData() works

--- a/software/libinfnoise_private.h
+++ b/software/libinfnoise_private.h
@@ -51,14 +51,14 @@ void inmDumpStats(void);
 
 extern double inmK, inmExpectedEntropyPerBit;
 
-bool initializeUSB(struct ftdi_context *ftdic, char **message,char *serial);
+bool initializeUSB(struct ftdi_context *ftdic, const char **message,char *serial);
 void prepareOutputBuffer();
 
 struct timespec;
 double diffTime(struct timespec *start, struct timespec *end);
-uint32_t extractBytes(uint8_t *bytes, uint32_t length, uint8_t *inBuf, char **message, bool *errorFlag);
+uint32_t extractBytes(uint8_t *bytes, uint32_t length, uint8_t *inBuf, const char **message, bool *errorFlag);
 
-bool outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, bool writeDevRandom, char **message);
+bool outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, bool writeDevRandom, const char **message);
 
 uint32_t processBytes(uint8_t *bytes, uint8_t *result, uint32_t *entropy, uint32_t *numBits, uint32_t *bytesWritten, bool raw,
                       uint32_t outputMultiplier);

--- a/software/libinfnoise_private.h
+++ b/software/libinfnoise_private.h
@@ -54,7 +54,6 @@ extern double inmK, inmExpectedEntropyPerBit;
 bool initializeUSB(struct ftdi_context *ftdic, const char **message,char *serial);
 void prepareOutputBuffer();
 
-struct timespec;
 double diffTime(struct timespec *start, struct timespec *end);
 uint32_t extractBytes(uint8_t *bytes, uint32_t length, uint8_t *inBuf, const char **message, bool *errorFlag);
 


### PR DESCRIPTION
In case listUSBdevices() fails, the recursive implementation is capable for a graceful cleanup.