### PR TITLE
udev: Fix systemd tag for /dev/infnoise, mtp-probe, ModemManager: ignore

### DIFF
--- a/software/init_scripts/75-infnoise.rules
+++ b/software/init_scripts/75-infnoise.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", SYMLINK+="infnoise", GROUP="dialout", MODE="0664"
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015" ,TAG+="systemd", ENV{SYSTEMD_WANTS}="infnoise.service"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{MTP_NO_PROBE}="1", TAG+="systemd", SYMLINK+="infnoise", GROUP="dialout", MODE="0664"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{MTP_NO_PROBE}="1", TAG+="systemd", ENV{SYSTEMD_WANTS}="infnoise.service"


### PR DESCRIPTION
- Add `TAGS+="systemd"` so `dev-infnoise.device` is created by SystemD automatically to resolve the SystemD service dependency from `infnoise.service`.
- Add environment variables `MTP_NO_PROBE=1`, and `ID_MM_DEVICE_IGNORE=1` to tell `mtp-probe` and `ModemManager` to ignore the `infnoise` USB devices.
- Fix the ` ,` typo to match udev style: `, ` (#93)

This PR resolves the following issues:

- Fixes #106 
  - Fixes leetronics/infnoise#34 (related issue on fork)
- Fixes #90
- Fixes #93


**Note:** @leetronics, @manuel-domke — This was found testing the 13-37.org `Infinite Noise TRNG` [from Crowd Supply][1] with `idVendor=0403`, `idProduct=6015` on Manjaro Linux (mostly equivalent to Arch Linux, using [`aur/infnoise 0.3.3-1`][2] @ [e94e011][3]).  @manuel-domke Let me know if I should make this PR against the fork: [`leetronics/infnoise`][4]

[1]: https://www.crowdsupply.com/leetronics/infinite-noise-trng
[2]: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=infnoise
[3]: https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=infnoise&id=e94e0118218e62108b5f83407687a7d853001eba
[4]: https://github.com/leetronics/infnoise