### PR TITLE
kmod: add test harness, fix stale references, add .gitignore

### DIFF
--- a/software/kernel/.gitignore
+++ b/software/kernel/.gitignore
@@ -1,0 +1,13 @@
+# Kernel build artifacts
+*.o
+*.ko
+*.mod
+*.mod.c
+.*.cmd
+Module.symvers
+modules.order
+.module-common*
+.tmp_versions/
+
+# Test binary
+test_infnoise

--- a/software/kernel/Makefile
+++ b/software/kernel/Makefile
@@ -29,7 +29,7 @@ modules:
 # Clean build artifacts
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
-	rm -f Module.symvers modules.order
+	rm -f Module.symvers modules.order test_infnoise
 
 # Install module
 install: modules
@@ -95,13 +95,31 @@ test-char:
 		echo "Error: No /dev/infnoise* device found"; \
 	fi
 
-# Run rngtest on hwrng output
-rngtest:
-	@echo "Running rngtest (1000 blocks)..."
-	@if [ -r /dev/hwrng ]; then \
-		cat /dev/hwrng | rngtest -c 1000 || true; \
+# Build userspace test harness
+test_infnoise: test_infnoise.c
+	$(CC) -Wall -Wextra -o $@ $<
+
+# Run all tests: kmod + entropy quality (~45s total)
+test: test_infnoise
+	@if ! lsmod | grep -q "^$(MODULE_NAME)"; then \
+		echo "Error: $(MODULE_NAME) module not loaded. Try: make load"; \
+		exit 1; \
+	fi
+	sudo ./test_infnoise
+	@echo ""
+	@echo "--- FIPS 140-2 (rngtest) ---"
+	@if command -v rngtest >/dev/null 2>&1 && [ -r /dev/hwrng ]; then \
+		dd if=/dev/hwrng bs=2500 count=100 2>/dev/null | rngtest; \
 	else \
-		echo "Error: /dev/hwrng not readable"; \
+		echo "  SKIP (rngtest not installed or /dev/hwrng not readable)"; \
+	fi
+	@echo ""
+	@echo "--- Shannon entropy (ent) ---"
+	@if command -v ent >/dev/null 2>&1 && [ -r /dev/hwrng ]; then \
+		dd if=/dev/hwrng bs=2500 count=100 of=/tmp/infnoise-ent.bin 2>/dev/null && \
+		ent /tmp/infnoise-ent.bin && rm -f /tmp/infnoise-ent.bin; \
+	else \
+		echo "  SKIP (ent not installed or /dev/hwrng not readable)"; \
 	fi
 
 # Show help
@@ -119,9 +137,9 @@ help:
 	@echo "  reload       - Unload and reload module"
 	@echo "  dmesg        - Show recent kernel messages from module"
 	@echo "  info         - Show module information"
-	@echo "  test-hwrng   - Test hwrng interface"
-	@echo "  test-char    - Test character device"
-	@echo "  rngtest      - Run rngtest on hwrng output"
+	@echo "  test         - Run all tests: kmod + rngtest + ent (~45s)"
+	@echo "  test-hwrng   - Dump hex from /dev/hwrng (visual check)"
+	@echo "  test-char    - Dump hex from /dev/infnoise0 (visual check)"
 	@echo ""
 	@echo "Variables:"
 	@echo "  KDIR         - Kernel source directory (default: /lib/modules/\$$(uname -r)/build)"
@@ -129,4 +147,4 @@ help:
 	@echo "Example:"
 	@echo "  make KDIR=/usr/src/linux-headers-6.1.0"
 
-.PHONY: all modules clean install uninstall load load-debug unload reload dmesg info test-hwrng test-char rngtest help
+.PHONY: all modules clean install uninstall load load-debug unload reload dmesg info test-hwrng test-char test help

--- a/software/kernel/Makefile
+++ b/software/kernel/Makefile
@@ -45,22 +45,22 @@ uninstall:
 load: modules
 	@if lsmod | grep -q "^$(MODULE_NAME)"; then \
 		echo "Module already loaded, unloading first..."; \
-		sudo rmmod $(MODULE_NAME); \
+		rmmod $(MODULE_NAME); \
 	fi
-	sudo insmod $(MODULE_NAME).ko
+	insmod $(MODULE_NAME).ko
 
 # Load with debug
 load-debug: modules
 	@if lsmod | grep -q "^$(MODULE_NAME)"; then \
 		echo "Module already loaded, unloading first..."; \
-		sudo rmmod $(MODULE_NAME); \
+		rmmod $(MODULE_NAME); \
 	fi
-	sudo insmod $(MODULE_NAME).ko debug=1
+	insmod $(MODULE_NAME).ko debug=1
 
 # Unload module
 unload:
 	@if lsmod | grep -q "^$(MODULE_NAME)"; then \
-		sudo rmmod $(MODULE_NAME); \
+		rmmod $(MODULE_NAME); \
 	else \
 		echo "Module not loaded"; \
 	fi
@@ -105,17 +105,17 @@ test: test_infnoise
 		echo "Error: $(MODULE_NAME) module not loaded. Try: make load"; \
 		exit 1; \
 	fi
-	sudo ./test_infnoise
+	./test_infnoise
 	@echo ""
 	@echo "--- FIPS 140-2 (rngtest) ---"
-	@if command -v rngtest >/dev/null 2>&1 && [ -r /dev/hwrng ]; then \
+	@if command -v rngtest >/dev/null 2>&1 && dd if=/dev/hwrng bs=1 count=1 >/dev/null 2>&1; then \
 		dd if=/dev/hwrng bs=2500 count=100 2>/dev/null | rngtest; \
 	else \
 		echo "  SKIP (rngtest not installed or /dev/hwrng not readable)"; \
 	fi
 	@echo ""
 	@echo "--- Shannon entropy (ent) ---"
-	@if command -v ent >/dev/null 2>&1 && [ -r /dev/hwrng ]; then \
+	@if command -v ent >/dev/null 2>&1 && dd if=/dev/hwrng bs=1 count=1 >/dev/null 2>&1; then \
 		dd if=/dev/hwrng bs=2500 count=100 of=/tmp/infnoise-ent.bin 2>/dev/null && \
 		ent /tmp/infnoise-ent.bin && rm -f /tmp/infnoise-ent.bin; \
 	else \

--- a/software/kernel/Makefile.intree
+++ b/software/kernel/Makefile.intree
@@ -6,7 +6,7 @@
 #
 # 1. Copy all source files to drivers/char/hw_random/infnoise/
 #    mkdir -p drivers/char/hw_random/infnoise
-#    cp infnoise.c infnoise_health.c infnoise_keccak.c infnoise.h \
+#    cp infnoise_main.c infnoise_health.c infnoise_keccak.c infnoise.h \
 #       drivers/char/hw_random/infnoise/
 #
 # 2. Copy Kconfig to drivers/char/hw_random/infnoise/Kconfig
@@ -23,7 +23,7 @@
 # --- Cut here for drivers/char/hw_random/infnoise/Makefile ---
 
 obj-$(CONFIG_HW_RANDOM_INFNOISE) += infnoise.o
-infnoise-y := infnoise.o infnoise_health.o infnoise_keccak.o
+infnoise-y := infnoise_main.o infnoise_health.o infnoise_keccak.o
 
 ccflags-$(CONFIG_HW_RANDOM_INFNOISE_DEBUG) += -DDEBUG
 
@@ -37,6 +37,6 @@ ccflags-$(CONFIG_HW_RANDOM_INFNOISE_DEBUG) += -DDEBUG
 #
 # In drivers/char/hw_random/Makefile, add:
 #   obj-$(CONFIG_HW_RANDOM_INFNOISE) += infnoise-trng.o
-#   infnoise-trng-y := infnoise.o infnoise_health.o infnoise_keccak.o
+#   infnoise-trng-y := infnoise_main.o infnoise_health.o infnoise_keccak.o
 #
 # And rename this Makefile.intree or merge Kconfig entries directly.

--- a/software/kernel/README.md
+++ b/software/kernel/README.md
@@ -28,7 +28,7 @@ See [Device Setup](#device-setup) for detailed instructions.
 sudo apt install linux-headers-$(uname -r) build-essential
 
 # Build
-cd infnoise-kmod
+cd software/kernel
 make
 
 # Load
@@ -123,7 +123,7 @@ sudo pacman -S linux-headers base-devel
 ### Compile
 
 ```bash
-cd infnoise-kmod
+cd software/kernel
 make
 ```
 

--- a/software/kernel/test_infnoise.c
+++ b/software/kernel/test_infnoise.c
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Userspace test harness for Infinite Noise TRNG kernel module
+ *
+ * Copyright (C) 2026 Avinash H. Duduskar
+ *
+ * Verifies driver mechanics: read interfaces, ioctl dispatch, non-blocking
+ * I/O, and device lifecycle.  Entropy quality testing is handled separately
+ * by test_entropy.sh (rngtest/ent/dieharder) and the project's tests/ suite.
+ *
+ * Requires: module loaded, device connected, root privileges.
+ *
+ * Build:  make test_infnoise
+ * Run:    sudo ./test_infnoise   (or: make test)
+ *
+ * VID/PID note: the module matches 0x1209:0x3701 (pid.codes registered).
+ * Stock Infinite Noise hardware ships as 0x0403:0x6015 (FTDI generic).
+ * To test on unmodified hardware, temporarily change INFNOISE_VENDOR_ID
+ * and INFNOISE_PRODUCT_ID in infnoise.h, rebuild, rmmod ftdi_sio, and
+ * insmod the patched module.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+
+/* Must match kernel header exactly */
+struct infnoise_stats {
+	uint64_t total_bits;
+	uint32_t total_ones;
+	uint32_t total_zeros;
+	uint32_t even_misfires;
+	uint32_t odd_misfires;
+	uint32_t entropy_estimate;
+	uint32_t k_estimate;
+	uint8_t warmup_complete;
+	uint8_t health_ok;
+	uint8_t __pad[6];
+} __attribute__((aligned(8)));
+
+#define INFNOISE_IOC_MAGIC	'N'
+#define INFNOISE_GET_STATS	_IOR(INFNOISE_IOC_MAGIC, 1, struct infnoise_stats)
+#define INFNOISE_SET_RAW	_IOW(INFNOISE_IOC_MAGIC, 2, int)
+#define INFNOISE_GET_ENTROPY	_IOR(INFNOISE_IOC_MAGIC, 3, uint32_t)
+
+static int passed = 0, failed = 0, skipped = 0;
+
+#define TEST(name) printf("  %-50s ", name)
+#define PASS() do { printf("\033[32mPASS\033[0m\n"); passed++; } while(0)
+#define FAIL(msg) do { printf("\033[31mFAIL\033[0m (%s)\n", msg); failed++; } while(0)
+#define SKIP(msg) do { printf("\033[33mSKIP\033[0m (%s)\n", msg); skipped++; } while(0)
+
+/* ── Read interfaces ────────────────────────────────────── */
+
+static void test_chardev_read(int fd)
+{
+	uint8_t buf[256];
+	ssize_t n;
+
+	TEST("chardev read returns data");
+	n = read(fd, buf, sizeof(buf));
+	if (n < 0) {
+		FAIL(strerror(errno));
+		return;
+	}
+	if (n == 0) {
+		FAIL("got 0 bytes");
+		return;
+	}
+	printf("got %zd bytes ", n);
+	PASS();
+}
+
+static void test_hwrng_read(void)
+{
+	int fd;
+	uint8_t buf[64];
+	ssize_t n;
+
+	TEST("/dev/hwrng read returns data");
+	fd = open("/dev/hwrng", O_RDONLY);
+	if (fd < 0) {
+		SKIP(strerror(errno));
+		return;
+	}
+	n = read(fd, buf, sizeof(buf));
+	close(fd);
+	if (n < 0) {
+		FAIL(strerror(errno));
+		return;
+	}
+	if (n == 0) {
+		FAIL("got 0 bytes");
+		return;
+	}
+	printf("got %zd bytes ", n);
+	PASS();
+}
+
+/* ── Non-blocking I/O ───────────────────────────────────── */
+
+static void test_nonblock(void)
+{
+	TEST("O_NONBLOCK returns EAGAIN or data");
+	int fd = open("/dev/infnoise0", O_RDONLY | O_NONBLOCK);
+	if (fd < 0) {
+		FAIL(strerror(errno));
+		return;
+	}
+	uint8_t buf[64];
+	ssize_t n = read(fd, buf, sizeof(buf));
+	close(fd);
+
+	if (n > 0) {
+		printf("got %zd bytes ", n);
+		PASS();
+	} else if (n < 0 && errno == EAGAIN) {
+		printf("EAGAIN (device warming up) ");
+		PASS();
+	} else if (n < 0) {
+		FAIL(strerror(errno));
+	} else {
+		FAIL("unexpected 0 return");
+	}
+}
+
+/* ── Ioctl interface ────────────────────────────────────── */
+
+static void test_ioctl_get_stats(int fd)
+{
+	struct infnoise_stats stats;
+
+	TEST("GET_STATS returns sane values");
+	memset(&stats, 0xAA, sizeof(stats));
+
+	if (ioctl(fd, INFNOISE_GET_STATS, &stats) < 0) {
+		FAIL(strerror(errno));
+		return;
+	}
+
+	if (!stats.warmup_complete) {
+		FAIL("warmup_complete is 0");
+		return;
+	}
+	if (!stats.health_ok) {
+		FAIL("health_ok is 0");
+		return;
+	}
+
+	printf("bits=%lu ones=%u zeros=%u ",
+	       (unsigned long)stats.total_bits, stats.total_ones,
+	       stats.total_zeros);
+	PASS();
+}
+
+static void test_ioctl_get_entropy(int fd)
+{
+	uint32_t entropy = 0;
+
+	TEST("GET_ENTROPY returns non-zero");
+	if (ioctl(fd, INFNOISE_GET_ENTROPY, &entropy) < 0) {
+		FAIL(strerror(errno));
+		return;
+	}
+	if (entropy == 0) {
+		FAIL("entropy is 0");
+		return;
+	}
+	printf("entropy=%u ", entropy);
+	PASS();
+}
+
+static void test_ioctl_set_raw(int fd)
+{
+	int raw = 0;
+
+	TEST("SET_RAW accepts value");
+	if (ioctl(fd, INFNOISE_SET_RAW, &raw) < 0) {
+		FAIL(strerror(errno));
+		return;
+	}
+	PASS();
+}
+
+static void test_ioctl_bad_cmd(int fd)
+{
+	TEST("invalid ioctl returns ENOTTY");
+	int ret = ioctl(fd, _IO('N', 99), NULL);
+	if (ret == -1 && errno == ENOTTY) {
+		PASS();
+	} else {
+		char buf[64];
+		snprintf(buf, sizeof(buf), "ret=%d errno=%d (%s)",
+			 ret, errno, strerror(errno));
+		FAIL(buf);
+	}
+}
+
+/* ── Device lifecycle ───────────────────────────────────── */
+
+static void test_open_close_reopen(void)
+{
+	TEST("open/close/reopen 5 times");
+
+	for (int i = 0; i < 5; i++) {
+		int fd = open("/dev/infnoise0", O_RDONLY);
+		if (fd < 0) {
+			char msg[64];
+			snprintf(msg, sizeof(msg), "open %d: %s", i, strerror(errno));
+			FAIL(msg);
+			return;
+		}
+		uint8_t buf[32];
+		ssize_t n = read(fd, buf, sizeof(buf));
+		close(fd);
+		if (n <= 0) {
+			char msg[64];
+			snprintf(msg, sizeof(msg), "read %d: %zd bytes", i, n);
+			FAIL(msg);
+			return;
+		}
+	}
+	printf("5 cycles OK ");
+	PASS();
+}
+
+/* ── Main ───────────────────────────────────────────────── */
+
+int main(void)
+{
+	int fd;
+
+	printf("\nInfinite Noise TRNG Kernel Module — Test Harness\n");
+	printf("=================================================\n\n");
+
+	fd = open("/dev/infnoise0", O_RDONLY);
+	if (fd < 0) {
+		fprintf(stderr, "Cannot open /dev/infnoise0: %s\n", strerror(errno));
+		fprintf(stderr, "Is the module loaded? Try: sudo insmod infnoise.ko\n");
+		return 1;
+	}
+
+	printf("--- Read interfaces ---\n");
+	test_chardev_read(fd);
+	test_hwrng_read();
+
+	printf("\n--- Non-blocking I/O ---\n");
+	test_nonblock();
+
+	printf("\n--- Ioctl interface ---\n");
+	test_ioctl_get_stats(fd);
+	test_ioctl_get_entropy(fd);
+	test_ioctl_set_raw(fd);
+	test_ioctl_bad_cmd(fd);
+
+	printf("\n--- Device lifecycle ---\n");
+	test_open_close_reopen();
+
+	close(fd);
+
+	printf("\n=================================================\n");
+	printf("Results: %d passed, %d failed, %d skipped\n\n",
+	       passed, failed, skipped);
+
+	return failed > 0 ? 1 : 0;
+}

--- a/software/kernel/test_infnoise.c
+++ b/software/kernel/test_infnoise.c
@@ -5,8 +5,8 @@
  * Copyright (C) 2026 Avinash H. Duduskar
  *
  * Verifies driver mechanics: read interfaces, ioctl dispatch, non-blocking
- * I/O, and device lifecycle.  Entropy quality testing is handled separately
- * by test_entropy.sh (rngtest/ent/dieharder) and the project's tests/ suite.
+ * I/O, and device lifecycle.  Entropy quality testing is handled by
+ * make test (rngtest, ent) and the project's tests/runtests.sh suite.
  *
  * Requires: module loaded, device connected, root privileges.
  *


### PR DESCRIPTION
## Summary

- Add userspace test harness (`test_infnoise.c`) for the kernel module
- Add unified `make test` target: runs 8 kmod tests, then FIPS 140-2 via `rngtest`, then Shannon entropy via `ent`
- Fix stale file references in `README.md`, `Makefile.intree`, and test header comment
- Add `.gitignore` for kernel build artifacts

## Test harness

8 tests covering `chardev` reads, `hwrng` reads, non-blocking I/O, `ioctl` dispatch (`GET_STATS`, `GET_ENTROPY`, `SET_RAW`, invalid command), and `open`/`close`/`reopen` cycling. Entropy quality testing delegated to `rngtest` and `ent`, consistent with the existing `tests/runtests.sh` approach.

Requires: kernel module loaded, device connected and root.

```bash
make                  # build module
insmod infnoise.ko    # load
make test             # 8 kmod tests + rngtest + ent
```

`rngtest` and `ent` are optional, `make test` skips them with a message if not installed.

## Stale reference fixes

- `README.md` build instructions reference `cd infnoise-kmod` which doesn't exist — changed to `cd software/kernel` (2 places)
- `Makefile.intree` references `infnoise.c` as the main source file but the actual file is `infnoise_main.c` (3 places)
- `test_infnoise.c` header referenced a nonexistent `test_entropy.sh` script — updated to point to `make test` and `tests/runtests.sh`

## Tested

Built and tested on Arch Linux, kernel 6.18.21-1-lts, Infinite Noise TRNG (FT-X).

| Test | Result |
|------|--------|
| kmod harness | 8/8 pass |
| FIPS 140-2 (rngtest) | 99/99 pass, 0 failures |
| Shannon entropy (ent) | 7.999819 bits/byte |

@manuel-domke **VID/PID note:** the module matches `1209:3701` (pid.codes registered). Stock hardware ships as `0403:6015` (FTDI generic). Tested by temporarily patching `INFNOISE_VENDOR_ID`/`INFNOISE_PRODUCT_ID` in `infnoise.h`, rebuilding, and loading after `rmmod ftdi_sio`.
