### PR TITLE
kmod: add DKMS support for persistent module installation

### DIFF
--- a/software/kernel/Makefile
+++ b/software/kernel/Makefile
@@ -41,6 +41,24 @@ uninstall:
 	rm -f /lib/modules/$(shell uname -r)/extra/$(MODULE_NAME).ko
 	depmod -a
 
+# DKMS version (must match dkms.conf PACKAGE_VERSION)
+DKMS_VERSION := 1.0
+DKMS_SRC := /usr/src/$(MODULE_NAME)-$(DKMS_VERSION)
+DKMS_SRCS := infnoise_main.c infnoise_health.c infnoise_keccak.c infnoise.h Makefile dkms.conf
+
+# Install module source for DKMS
+dkms-install:
+	install -d $(DKMS_SRC)
+	install -m 0644 $(DKMS_SRCS) $(DKMS_SRC)/
+	dkms add $(MODULE_NAME)/$(DKMS_VERSION)
+	dkms build $(MODULE_NAME)/$(DKMS_VERSION)
+	dkms install $(MODULE_NAME)/$(DKMS_VERSION)
+
+# Remove DKMS module
+dkms-uninstall:
+	dkms remove $(MODULE_NAME)/$(DKMS_VERSION) --all || true
+	rm -rf $(DKMS_SRC)
+
 # Load module
 load: modules
 	@if lsmod | grep -q "^$(MODULE_NAME)"; then \
@@ -113,6 +131,8 @@ help:
 	@echo "  clean        - Remove build artifacts"
 	@echo "  install      - Install module to system"
 	@echo "  uninstall    - Remove module from system"
+	@echo "  dkms-install - Install via DKMS (persists across kernel upgrades)"
+	@echo "  dkms-uninstall - Remove DKMS module"
 	@echo "  load         - Load module with insmod"
 	@echo "  load-debug   - Load module with debug enabled"
 	@echo "  unload       - Unload module with rmmod"
@@ -129,4 +149,4 @@ help:
 	@echo "Example:"
 	@echo "  make KDIR=/usr/src/linux-headers-6.1.0"
 
-.PHONY: all modules clean install uninstall load load-debug unload reload dmesg info test-hwrng test-char rngtest help
+.PHONY: all modules clean install uninstall dkms-install dkms-uninstall load load-debug unload reload dmesg info test-hwrng test-char rngtest help

--- a/software/kernel/dkms.conf
+++ b/software/kernel/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="infnoise"
+PACKAGE_VERSION="1.0"
+
+BUILT_MODULE_NAME[0]="infnoise"
+DEST_MODULE_LOCATION[0]="/extra"
+
+AUTOINSTALL="yes"


### PR DESCRIPTION
### Summary
This enables Linux distributions to automatically trigger a build / re-build of the kernel module whenever required via [modern DKMS](https://wiki.archlinux.org/title/Dynamic_Kernel_Module_Support).

### Changes
Add `dkms.conf` and `Makefile` targets (`dkms-install`, `dkms-uninstall`) so the module persists across kernel upgrades without manual rebuilds. This should also fix most build issues with custom kernels _assuming sane configurations_.
Closes https://github.com/waywardgeek/infnoise/issues/109 and https://github.com/waywardgeek/infnoise/issues/110.

Usage:
```
  make dkms-install    # add, build, install via DKMS
  make dkms-uninstall  # remove DKMS module and source
```
Tested:
`dkms add`/`build`/`install`/`remove` cycle on Arch Linux, kernel 6.18.21-1-lts. `modinfo` confirms module available via `depmod` after DKMS install.

Co-Authored-By: Claude Opus