### PR TITLE
kmod: fix double-counting of bytes_generated

### DIFF
--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -674,9 +674,6 @@ static int infnoise_hwrng_read(struct hwrng *rng, void *data, size_t max,
 	ret = infnoise_read_data(dev, data, max, raw);
 	mutex_unlock(&dev->lock);
 
-	if (ret > 0)
-		dev->bytes_generated += ret;
-
 	return ret;
 }
 
@@ -791,7 +788,6 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 			return -EFAULT;
 
 		total += ret;
-		dev->bytes_generated += ret;
 	}
 
 	return total;


### PR DESCRIPTION
### Fix double-counting of generated bytes

`infnoise_read_data()` already increments `dev->bytes_generated` on every successful return path (lines 540, 568, 595).

However, both:
- `infnoise_hwrng_read()`
- `infnoise_char_read()`

add a second increment after calling `infnoise_read_data()`, resulting in **double-counting** of generated bytes.

### Fix

Remove the duplicate increments in the callers.

---

### Testing

- Built with VID/PID patched to `0x0403:0x6015` (stock FTDI)
- Kernel: `6.18.21-1-lts`
- Hardware: Infinite Noise TRNG

Results:
- ✅ 10/10 tests pass (see [`test_infnoise.c`](https://github.com/waywardgeek/infnoise/blob/master/software/kernel/test_infnoise.c)

> Note: VID/PID change is **local-only for testing**.  
> The committed code retains `0x1209:0x3701` as intended upstream.

Co-Authored by Claude Opus