### PR TITLE
kmod: fix busy-wait spin in infnoise_char_read on zero-length return

### DIFF
--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -779,11 +779,15 @@ static ssize_t infnoise_char_read(struct file *file, char __user *buf,
 			return total ? total : ret;
 
 		if (ret == 0) {
-			/* No data available, try again */
+			/* No data available yet (warmup / entropy below target) */
 			if (total > 0)
 				break;
 			if (file->f_flags & O_NONBLOCK)
 				return -EAGAIN;
+			/* Yield CPU and back off to avoid busy-wait / soft lockup */
+			msleep(INFNOISE_RETRY_DELAY_MS);
+			if (signal_pending(current))
+				return -ERESTARTSYS;
 			continue;
 		}
 

--- a/software/kernel/test_infnoise.c
+++ b/software/kernel/test_infnoise.c
@@ -25,8 +25,11 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <signal.h>
 #include <sys/ioctl.h>
+#include <sys/wait.h>
 #include <stdint.h>
+#include <time.h>
 
 /* Must match kernel header exactly */
 struct infnoise_stats {
@@ -125,6 +128,69 @@ static void test_nonblock(void)
 		FAIL(strerror(errno));
 	} else {
 		FAIL("unexpected 0 return");
+	}
+}
+
+/*
+ * Regression test: blocking read must be interruptible by signal.
+ *
+ * Forks a child that reads in a blocking loop, parent sends SIGUSR1
+ * after 500ms.  The child should exit cleanly via EINTR.  If the
+ * driver's retry loop doesn't check signal_pending(), the child
+ * hangs forever.
+ */
+static volatile sig_atomic_t child_got_signal = 0;
+static void child_handler(int sig) { (void)sig; child_got_signal = 1; }
+
+static void test_interruptible(void)
+{
+	TEST("blocking read is interruptible by signal");
+
+	pid_t pid = fork();
+	if (pid < 0) {
+		FAIL(strerror(errno));
+		return;
+	}
+
+	if (pid == 0) {
+		signal(SIGUSR1, child_handler);
+		int fd = open("/dev/infnoise0", O_RDONLY);
+		if (fd < 0) _exit(2);
+
+		uint8_t buf[64];
+		while (!child_got_signal) {
+			ssize_t n = read(fd, buf, sizeof(buf));
+			if (n < 0 && errno == EINTR) {
+				close(fd);
+				_exit(0);
+			}
+			if (n < 0) {
+				close(fd);
+				_exit(3);
+			}
+		}
+		close(fd);
+		_exit(0);
+	}
+
+	usleep(500000);
+	kill(pid, SIGUSR1);
+
+	int status;
+	struct timespec ts = { .tv_sec = 3, .tv_nsec = 0 };
+	nanosleep(&ts, NULL);
+
+	pid_t ret = waitpid(pid, &status, WNOHANG);
+	if (ret == 0) {
+		kill(pid, SIGKILL);
+		waitpid(pid, &status, 0);
+		FAIL("child hung (busy-wait or uninterruptible)");
+	} else if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+		PASS();
+	} else {
+		char msg[64];
+		snprintf(msg, sizeof(msg), "child exit=%d", WEXITSTATUS(status));
+		FAIL(msg);
 	}
 }
 
@@ -250,6 +316,7 @@ int main(void)
 
 	printf("\n--- Non-blocking I/O ---\n");
 	test_nonblock();
+	test_interruptible();
 
 	printf("\n--- Ioctl interface ---\n");
 	test_ioctl_get_stats(fd);


### PR DESCRIPTION
### Fix busy-loop on zero-length reads

When `infnoise_read_data()` returns `0` (e.g. health check not ready or entropy below target), the blocking read loop immediately re-enters without any sleep or scheduling.

This results in:
- CPU core being pinned at 100%
- Potential soft lockup warnings under `CONFIG_DETECT_SOFTLOCKUP`

### Fix

Ensure the blocking read loop yields appropriately (e.g. via sleep or scheduling) when no data is available, preventing a tight busy-loop.