### PR TITLE
kmod: fix GET_STATS infoleak and 32-bit compat ioctl

### DIFF
--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -137,18 +137,26 @@ extern bool infnoise_raw_mode;
 #define INFNOISE_SET_RAW	_IOW(INFNOISE_IOC_MAGIC, 2, int)
 #define INFNOISE_GET_ENTROPY	_IOR(INFNOISE_IOC_MAGIC, 3, u32)
 
-/* Statistics structure for ioctl */
+/*
+ * Statistics structure for ioctl (UAPI)
+ *
+ * Layout must be identical on 32-bit and 64-bit so that a 32-bit
+ * userspace process can issue INFNOISE_GET_STATS on a 64-bit kernel.
+ * Explicit padding ensures sizeof() == 40 on both, and __aligned(8)
+ * forces u64 alignment on 32-bit where u64 is normally 4-byte aligned.
+ */
 struct infnoise_stats {
-	u64 total_bits;
-	u32 total_ones;
-	u32 total_zeros;
-	u32 even_misfires;
-	u32 odd_misfires;
-	u32 entropy_estimate;	/* Fixed-point */
-	u32 k_estimate;		/* Fixed-point */
-	u8 warmup_complete;
-	u8 health_ok;
-};
+	__u64 total_bits;
+	__u32 total_ones;
+	__u32 total_zeros;
+	__u32 even_misfires;
+	__u32 odd_misfires;
+	__u32 entropy_estimate;	/* Fixed-point 16.16 */
+	__u32 k_estimate;	/* Fixed-point 16.16 */
+	__u8 warmup_complete;
+	__u8 health_ok;
+	__u8 __pad[6];
+} __aligned(8);
 
 /* Health check state */
 struct infnoise_health {

--- a/software/kernel/infnoise_health.c
+++ b/software/kernel/infnoise_health.c
@@ -429,6 +429,7 @@ bool infnoise_health_entropy_on_target(struct infnoise_health *health,
 void infnoise_health_get_stats(struct infnoise_health *health,
 			       struct infnoise_stats *stats)
 {
+	memset(stats, 0, sizeof(*stats));
 	stats->total_bits = health->total_bits;
 	stats->total_ones = health->total_ones;
 	stats->total_zeros = health->total_zeros;

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -20,6 +20,8 @@
 #include <linux/hw_random.h>
 #include <linux/workqueue.h>
 #include <linux/uaccess.h>
+#include <linux/compat.h>
+#include <linux/sched/signal.h>
 #include <linux/delay.h>
 #include "infnoise.h"
 
@@ -843,6 +845,7 @@ static const struct file_operations infnoise_fops = {
 	.release	= infnoise_release,
 	.llseek		= noop_llseek,
 	.unlocked_ioctl	= infnoise_ioctl,
+	.compat_ioctl	= compat_ptr_ioctl,
 };
 
 static struct usb_class_driver infnoise_class = {

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -801,7 +801,7 @@ static long infnoise_ioctl(struct file *file, unsigned int cmd,
 			   unsigned long arg)
 {
 	struct infnoise_device *dev = file->private_data;
-	struct infnoise_stats stats;
+	struct infnoise_stats stats = {};
 	int raw;
 	u32 entropy;
 

--- a/software/kernel/test_infnoise.c
+++ b/software/kernel/test_infnoise.c
@@ -130,6 +130,25 @@ static void test_nonblock(void)
 
 /* ── Ioctl interface ────────────────────────────────────── */
 
+/*
+ * Regression test: struct must be 40 bytes on all architectures.
+ *
+ * With __aligned(8) and explicit __pad[6], the struct is 40 bytes on
+ * both 32-bit and 64-bit.  Without it, 32-bit compilers produce 36
+ * bytes, causing _IOR to encode a different ioctl number.
+ */
+static void test_struct_size(void)
+{
+	TEST("sizeof(infnoise_stats) == 40");
+	if (sizeof(struct infnoise_stats) == 40) {
+		PASS();
+	} else {
+		char msg[64];
+		snprintf(msg, sizeof(msg), "got %zu", sizeof(struct infnoise_stats));
+		FAIL(msg);
+	}
+}
+
 static void test_ioctl_get_stats(int fd)
 {
 	struct infnoise_stats stats;
@@ -154,6 +173,36 @@ static void test_ioctl_get_stats(int fd)
 	printf("bits=%lu ones=%u zeros=%u ",
 	       (unsigned long)stats.total_bits, stats.total_ones,
 	       stats.total_zeros);
+	PASS();
+}
+
+/*
+ * Regression test: padding bytes in infnoise_stats must be zeroed.
+ *
+ * Pre-fills the struct with 0xAA, then calls GET_STATS.  If the kernel
+ * doesn't memset the struct before copy_to_user, the 6 padding bytes
+ * (offsets 34-39) contain uninitialized kernel stack data — an info leak.
+ */
+static void test_padding_zeroed(int fd)
+{
+	struct infnoise_stats stats;
+
+	TEST("GET_STATS padding bytes zeroed (info leak check)");
+	memset(&stats, 0xAA, sizeof(stats));
+
+	if (ioctl(fd, INFNOISE_GET_STATS, &stats) < 0) {
+		FAIL(strerror(errno));
+		return;
+	}
+
+	int pad_ok = 1;
+	for (int i = 0; i < 6; i++) {
+		if (stats.__pad[i] != 0) pad_ok = 0;
+	}
+	if (!pad_ok) {
+		FAIL("padding bytes not zeroed (kernel stack info leak)");
+		return;
+	}
 	PASS();
 }
 
@@ -252,7 +301,9 @@ int main(void)
 	test_nonblock();
 
 	printf("\n--- Ioctl interface ---\n");
+	test_struct_size();
 	test_ioctl_get_stats(fd);
+	test_padding_zeroed(fd);
 	test_ioctl_get_entropy(fd);
 	test_ioctl_set_raw(fd);
 	test_ioctl_bad_cmd(fd);


### PR DESCRIPTION
Three commits fixing a security issue and a portability bug in the
`INFNOISE_GET_STATS` ioctl path.  All three touch the same struct and
ioctl handler, so they ship as one PR; the leading commit is a
standalone security fix that can be cherry-picked cleanly.

## 1. Kernel stack infoleak (CWE-200)

`infnoise_ioctl()` declared `struct infnoise_stats stats` on the stack
and copied the full `sizeof(stats) == 40` bytes to userspace.
`infnoise_health_get_stats()` only fills the nine named fields (34
bytes); the six bytes of trailing padding required by `u64` alignment
were uninitialized kernel stack, leaked to userspace on every call.
Trivially observable by any user with read access to `/dev/infnoise0`.

Fix: zero-initialize the struct at declaration (`= {}`).

## 2. 32-bit userspace on 64-bit kernels

`struct infnoise_stats` contains a `u64` followed by `u32`/`u8` fields.
On 64-bit kernels the struct is 40 bytes; on 32-bit it's 36 bytes
because `u64` has 4-byte alignment there.  `_IOR` encodes `sizeof()`
into the ioctl number, so a 32-bit process on a 64-bit kernel gets a
different ioctl number — the ioctl either returns garbage or `-ENOTTY`.

Fix:
- Explicit `__pad[6]` and `__aligned(8)` on `infnoise_stats` → 40 bytes
  with identical layout on both architectures.
- UAPI-safe fixed-width types (`__u64`/`__u32`/`__u8`).
- `.compat_ioctl = compat_ptr_ioctl` routes 32-bit calls to the native
  handler.
- Zero the struct in `infnoise_health_get_stats()` as belt-and-braces
  alongside commit 1.

## 3. Regression tests

Two tests added to `test_infnoise.c`:
- `test_struct_size()` — asserts `sizeof(infnoise_stats) == 40`.
- `test_padding_zeroed()` — pre-fills with `0xAA`, calls `GET_STATS`,
  verifies the 6 padding bytes are zero.

## Test plan
- [x] Builds on kernel 6.18.21 (lts).
- [x] Full test harness passes (10/10) on real Infinite Noise TRNG
      hardware.  Verified locally with VID/PID patched to stock
      `0x0403:0x6015` for testing; committed code retains the
      upstream `0x1209:0x3701`.
- [ ] 32-bit userspace binary against 64-bit kernel — not tested locally;
      covered by the struct-size assertion.
      
Co-authored by Claude Opus