### PR TITLE
libinfnoise: signed readData return, drop errorFlag

### DIFF
--- a/software/examples/libinfnoise/example-complex.c
+++ b/software/examples/libinfnoise/example-complex.c
@@ -34,16 +34,13 @@ int main()
     while (totalBytesWritten < 1000000) {
         uint8_t result[resultSize];
 
-	// readRawData returns the number of bytes written to result array
-        uint64_t bytesWritten = readData(&context, result, !initKeccak, multiplier);
-
-	// check for errors
-	// note: bytesWritten is also 0 in this case, but an errorFlag is needed as
-        // bytesWritten can also be 0 when data hasn't passed the health monitor.
-        if (context.errorFlag) {
+	// readData returns bytes written (>0), transient (0), or error (<0)
+        int32_t rc = readData(&context, result, !initKeccak, multiplier);
+        if (rc < 0) {
             fprintf(stderr, "Error: %s\n", context.message);
             return -1;
         }
+        uint32_t bytesWritten = (uint32_t)rc;
 	totalBytesWritten += bytesWritten;
         fprintf(stderr, "infnoise bytes read: %lu\n", (unsigned long) totalBytesWritten);
 

--- a/software/examples/libinfnoise/example-simple.c
+++ b/software/examples/libinfnoise/example-simple.c
@@ -29,18 +29,13 @@ int main()
     while (totalBytesWritten < 1000000) {
         uint8_t result[resultSize];
 
-	context.errorFlag = false;
-	// readRawData returns the number of bytes written to result array
-        uint64_t bytesWritten = readData(&context, result, !initKeccak, multiplier);
-
-	// check for errors
-	// note: bytesWritten is also 0 in this case, but an errorFlag is needed as
-        // bytesWritten can also be 0 when data hasn't passed the health monitor.
-	// (which happens sometimes in normal operation - and is expected behaviour)
-        if (context.errorFlag) {
+	// readData returns bytes written (>0), transient (0), or error (<0)
+        int32_t rc = readData(&context, result, !initKeccak, multiplier);
+        if (rc < 0) {
             fprintf(stderr, "Error: %s\n", context.message);
             return -1;
         }
+        uint32_t bytesWritten = (uint32_t)rc;
 
         // print as many bytes as readData told us
         fwrite(result, 1, bytesWritten, stdout);

--- a/software/healthcheck.c
+++ b/software/healthcheck.c
@@ -31,88 +31,72 @@ confirmed.
 #define INM_MAX_SEQUENCE 20u
 #define INM_MAX_COUNT (1u << 14u)
 
-double inmK, inmExpectedEntropyPerBit;
-
-static uint8_t inmN;
-static uint32_t inmPrevBits;
-static uint32_t inmNumBitsSampled;
-static uint32_t *inmOnesEven, *inmZerosEven;
-static uint32_t *inmOnesOdd, *inmZerosOdd;
-// The total probability of generating the string of states we did is
-// 1/(2^inmNumBitsOfEntropy * inmCurrentProbability).
-static uint32_t inmNumBitsOfEntropy;
-static double inmCurrentProbability;
-static uint64_t inmTotalBits;
-static bool inmPrevBit;
-static uint32_t inmEntropyLevel;
-static uint32_t inmNumSequentialZeros, inmNumSequentialOnes;
-static uint32_t inmTotalOnes, inmTotalZeros;
-static uint32_t inmEvenMisfires, inmOddMisfires;
-static bool inmPrevEven, inmPrevOdd;
-static bool inmDebug;
-
 // Print the tables of statistics.
-void inmDumpStats(void) {
+void inmDumpStats(struct infnoise_health_state *hc) {
     uint32_t i;
-    for(i = 0u; i < 1u << inmN; i++) {
+    for(i = 0u; i < 1u << hc->N; i++) {
         printf("%x onesEven:%u zerosEven:%u onesOdd:%u zerosOdd:%u\n",
-            i, inmOnesEven[i], inmZerosEven[i], inmOnesOdd[i], inmZerosOdd[i]);
+            i, hc->onesEven[i], hc->zerosEven[i], hc->onesOdd[i], hc->zerosOdd[i]);
     }
 }
 
 // Free memory used by the health check.
-void inmHealthCheckStop(void) {
-    if(inmOnesEven != NULL) {
-        free(inmOnesEven);
+void inmHealthCheckStop(struct infnoise_health_state *hc) {
+    if(hc->onesEven != NULL) {
+        free(hc->onesEven);
+        hc->onesEven = NULL;
     }
-    if(inmZerosEven != NULL) {
-        free(inmZerosEven);
+    if(hc->zerosEven != NULL) {
+        free(hc->zerosEven);
+        hc->zerosEven = NULL;
     }
-    if(inmOnesOdd != NULL) {
-        free(inmOnesOdd);
+    if(hc->onesOdd != NULL) {
+        free(hc->onesOdd);
+        hc->onesOdd = NULL;
     }
-    if(inmZerosOdd != NULL) {
-        free(inmZerosOdd);
+    if(hc->zerosOdd != NULL) {
+        free(hc->zerosOdd);
+        hc->zerosOdd = NULL;
     }
 }
 
 // Reset the statistics.
-static void resetStats(void) {
-    inmNumBitsSampled = 0u;
-    inmCurrentProbability = 1.0;
-    inmNumBitsOfEntropy = 0u;
-    inmEntropyLevel = 0u;
-    inmTotalOnes = 0u;
-    inmTotalZeros = 0u;
-    inmEvenMisfires = 0u;
-    inmOddMisfires = 0u;
+static void resetStats(struct infnoise_health_state *hc) {
+    hc->numBitsSampled = 0u;
+    hc->currentProbability = 1.0;
+    hc->numBitsOfEntropy = 0u;
+    hc->entropyLevel = 0u;
+    hc->totalOnes = 0u;
+    hc->totalZeros = 0u;
+    hc->evenMisfires = 0u;
+    hc->oddMisfires = 0u;
 }
 
 // Initialize the health check.  N is the number of bits used to predict the next bit.
 // At least 8 bits must be used, and no more than 30.  In general, we should use bits
 // large enough so that INM output will be uncorrelated with bits N samples back in time.
-bool inmHealthCheckStart(uint8_t N, double K, bool debug) {
+bool inmHealthCheckStart(struct infnoise_health_state *hc, uint8_t N, double K, bool debug) {
     if(N < 1u || N > 30u) {
         return false;
     }
-    inmDebug = debug;
-    inmNumBitsOfEntropy = 0u;
-    inmCurrentProbability = 1.0;
-    inmK = K;
-    inmN = N;
-    inmPrevBits = 0u;
-    inmOnesEven = calloc((size_t)1u << N, sizeof(*inmOnesEven));
-    inmZerosEven = calloc((size_t)1u << N, sizeof(*inmZerosEven));
-    inmOnesOdd = calloc((size_t)1u << N, sizeof(*inmOnesOdd));
-    inmZerosOdd = calloc((size_t)1u << N, sizeof(*inmZerosOdd));
-    inmExpectedEntropyPerBit = log(K)/log(2.0);
-    inmTotalBits = 0u;
-    inmPrevBit = false;
-    inmNumSequentialZeros = 0u;
-    inmNumSequentialOnes = 0u;
-    resetStats();
-    if(inmOnesEven == NULL || inmZerosEven == NULL || inmOnesOdd == NULL || inmZerosOdd == NULL) {
-        inmHealthCheckStop();
+    hc->debug = debug;
+    hc->numBitsOfEntropy = 0u;
+    hc->currentProbability = 1.0;
+    hc->K = K;
+    hc->N = N;
+    hc->prevBits = 0u;
+    hc->onesEven = calloc((size_t)1u << N, sizeof(*hc->onesEven));
+    hc->zerosEven = calloc((size_t)1u << N, sizeof(*hc->zerosEven));
+    hc->onesOdd = calloc((size_t)1u << N, sizeof(*hc->onesOdd));
+    hc->zerosOdd = calloc((size_t)1u << N, sizeof(*hc->zerosOdd));
+    hc->expectedEntropyPerBit = log(K)/log(2.0);
+    hc->totalBits = 0u;
+    hc->prevBit = false;
+    hc->numSequentialZeros = 0u;
+    hc->numSequentialOnes = 0u;
+    resetStats(hc);
+    if(hc->onesEven == NULL || hc->zerosEven == NULL || hc->onesOdd == NULL || hc->zerosOdd == NULL) {
+        inmHealthCheckStop(hc);
         return false;
     }
     return true;
@@ -120,175 +104,175 @@ bool inmHealthCheckStart(uint8_t N, double K, bool debug) {
 
 // If running continuously, it is possible to start overflowing the 32-bit counters for
 // zeros and ones.  Check for this, and scale the stats if needed.
-static void scaleStats(void) {
+static void scaleStats(struct infnoise_health_state *hc) {
     uint32_t i;
-    for(i = 0u; i < (1u << inmN); i++) {
-        inmZerosEven[i] >>= 1u;
-        inmOnesEven[i] >>= 1u;
-        inmZerosOdd[i] >>= 1u;
-        inmOnesOdd[i] >>= 1u;
+    for(i = 0u; i < (1u << hc->N); i++) {
+        hc->zerosEven[i] >>= 1u;
+        hc->onesEven[i] >>= 1u;
+        hc->zerosOdd[i] >>= 1u;
+        hc->onesOdd[i] >>= 1u;
     }
 }
 
 // If running continuously, it is possible to start overflowing the 32-bit counters for
 // zeros and ones.  Check for this, and scale the stats if needed.
-static void scaleEntropy(void) {
-    if(inmNumBitsSampled == INM_MIN_DATA) {
-        inmNumBitsOfEntropy >>= 1u;
-        inmNumBitsSampled >>= 1u;
-        inmEvenMisfires >>= 1u;
-        inmOddMisfires >>= 1u;
+static void scaleEntropy(struct infnoise_health_state *hc) {
+    if(hc->numBitsSampled == INM_MIN_DATA) {
+        hc->numBitsOfEntropy >>= 1u;
+        hc->numBitsSampled >>= 1u;
+        hc->evenMisfires >>= 1u;
+        hc->oddMisfires >>= 1u;
     }
 }
 
 // If running continuously, it is possible to start overflowing the 32-bit counters for
 // zeros and ones.  Check for this, and scale the stats if needed.
-static void scaleZeroOneCounts(void) {
-    uint64_t maxVal = inmTotalZeros >= inmTotalOnes? inmTotalZeros : inmTotalOnes;
+static void scaleZeroOneCounts(struct infnoise_health_state *hc) {
+    uint64_t maxVal = hc->totalZeros >= hc->totalOnes? hc->totalZeros : hc->totalOnes;
     if(maxVal == INM_MIN_DATA) {
-        inmTotalZeros >>= 1u;
-        inmTotalOnes >>= 1u;
+        hc->totalZeros >>= 1u;
+        hc->totalOnes >>= 1u;
     }
 }
 
 // This should be called for each bit generated.
-bool inmHealthCheckAddBit(bool evenBit, bool oddBit, bool even) {
+bool inmHealthCheckAddBit(struct infnoise_health_state *hc, bool evenBit, bool oddBit, bool even) {
     bool bit;
     if(even) {
         bit = evenBit;
-        inmEvenMisfires += (evenBit != inmPrevEven);
+        hc->evenMisfires += (evenBit != hc->prevEven);
     } else {
         bit = oddBit;
-        inmOddMisfires += (oddBit != inmPrevOdd);
+        hc->oddMisfires += (oddBit != hc->prevOdd);
     }
-    inmPrevEven = evenBit;
-    inmPrevOdd = oddBit;
-    inmTotalBits++;
-    if(inmDebug && (inmTotalBits & 0xfffffllu) == 0u) {
+    hc->prevEven = evenBit;
+    hc->prevOdd = oddBit;
+    hc->totalBits++;
+    if(hc->debug && (hc->totalBits & 0xfffffllu) == 0u) {
         fprintf(stderr, "Generated %llu bits.  %s to use data.  Estimated entropy per bit: %f, estimated K: %f\n",
-            (long long)inmTotalBits, inmHealthCheckOkToUseData()? "OK" : "NOT OK", inmHealthCheckEstimateEntropyPerBit(),
-            inmHealthCheckEstimateK());
+            (long long)hc->totalBits, inmHealthCheckOkToUseData(hc)? "OK" : "NOT OK", inmHealthCheckEstimateEntropyPerBit(hc),
+            inmHealthCheckEstimateK(hc));
         fprintf(stderr, "num1s:%f%%, even misfires:%f%%, odd misfires:%f%%\n",
-            inmTotalOnes*100.0/(inmTotalZeros + inmTotalOnes),
-            inmEvenMisfires*100.0/inmNumBitsSampled, inmOddMisfires*100.0/inmNumBitsSampled);
+            hc->totalOnes*100.0/(hc->totalZeros + hc->totalOnes),
+            hc->evenMisfires*100.0/hc->numBitsSampled, hc->oddMisfires*100.0/hc->numBitsSampled);
         fflush(stderr);
     }
-    inmPrevBits = (inmPrevBits << 1) & ((1 << inmN)-1);
-    if(inmPrevBit) {
-        inmPrevBits |= 1;
+    hc->prevBits = (hc->prevBits << 1) & ((1 << hc->N)-1);
+    if(hc->prevBit) {
+        hc->prevBits |= 1;
     }
-    inmPrevBit = bit;
-    if(inmNumBitsSampled > 100u) {
+    hc->prevBit = bit;
+    if(hc->numBitsSampled > 100u) {
         if(bit) {
-            inmTotalOnes++;
-            inmNumSequentialOnes++;
-            inmNumSequentialZeros = 0u;
-            if(inmNumSequentialOnes > INM_MAX_SEQUENCE) {
+            hc->totalOnes++;
+            hc->numSequentialOnes++;
+            hc->numSequentialZeros = 0u;
+            if(hc->numSequentialOnes > INM_MAX_SEQUENCE) {
                 fprintf(stderr, "Maximum sequence of %d 1's exceeded\n", INM_MAX_SEQUENCE);
-                inmNumSequentialOnes = 0u;
+                hc->numSequentialOnes = 0u;
                 return false;
             }
         } else {
-            inmTotalZeros++;
-            inmNumSequentialZeros++;
-            inmNumSequentialOnes = 0u;
-            if(inmNumSequentialZeros > INM_MAX_SEQUENCE) {
+            hc->totalZeros++;
+            hc->numSequentialZeros++;
+            hc->numSequentialOnes = 0u;
+            if(hc->numSequentialZeros > INM_MAX_SEQUENCE) {
                 fprintf(stderr, "Maximum sequence of %d 0's exceeded\n", INM_MAX_SEQUENCE);
-                inmNumSequentialZeros = 0u;
+                hc->numSequentialZeros = 0u;
                 return false;
             }
         }
     }
     uint32_t zeros, ones;
     if(even) {
-        zeros = inmZerosEven[inmPrevBits];
-        ones = inmOnesEven[inmPrevBits];
+        zeros = hc->zerosEven[hc->prevBits];
+        ones = hc->onesEven[hc->prevBits];
     } else {
-        zeros = inmZerosOdd[inmPrevBits];
-        ones = inmOnesOdd[inmPrevBits];
+        zeros = hc->zerosOdd[hc->prevBits];
+        ones = hc->onesOdd[hc->prevBits];
     }
     uint32_t total = zeros + ones;
     if(bit) {
         if(ones != 0u) {
-            inmCurrentProbability *= (double)ones/total;
+            hc->currentProbability *= (double)ones/total;
         }
     } else {
         if(zeros != 0u) {
-            inmCurrentProbability *= (double)zeros/total;
+            hc->currentProbability *= (double)zeros/total;
         }
     }
-    while(inmCurrentProbability <= 0.5) {
-        inmCurrentProbability *= 2.0;
-        inmNumBitsOfEntropy++;
-        if(inmHealthCheckOkToUseData()) {
-            inmEntropyLevel++;
+    while(hc->currentProbability <= 0.5) {
+        hc->currentProbability *= 2.0;
+        hc->numBitsOfEntropy++;
+        if(inmHealthCheckOkToUseData(hc)) {
+            hc->entropyLevel++;
         }
     }
-    //printf("probability:%f\n", inmCurrentProbability);
-    inmNumBitsSampled++;
+    //printf("probability:%f\n", hc->currentProbability);
+    hc->numBitsSampled++;
     if(bit) {
         if(even) {
-            inmOnesEven[inmPrevBits]++;
-            if(inmOnesEven[inmPrevBits] == INM_MAX_COUNT) {
-                scaleStats();
+            hc->onesEven[hc->prevBits]++;
+            if(hc->onesEven[hc->prevBits] == INM_MAX_COUNT) {
+                scaleStats(hc);
             }
         } else {
-            inmOnesOdd[inmPrevBits]++;
-            if(inmOnesOdd[inmPrevBits] == INM_MAX_COUNT) {
-                scaleStats();
+            hc->onesOdd[hc->prevBits]++;
+            if(hc->onesOdd[hc->prevBits] == INM_MAX_COUNT) {
+                scaleStats(hc);
             }
         }
     } else {
         if(even) {
-            inmZerosEven[inmPrevBits]++;
-            if(inmZerosEven[inmPrevBits] == INM_MAX_COUNT) {
-                scaleStats();
+            hc->zerosEven[hc->prevBits]++;
+            if(hc->zerosEven[hc->prevBits] == INM_MAX_COUNT) {
+                scaleStats(hc);
             }
         } else {
-            inmZerosOdd[inmPrevBits]++;
-            if(inmZerosOdd[inmPrevBits] == INM_MAX_COUNT) {
-                scaleStats();
+            hc->zerosOdd[hc->prevBits]++;
+            if(hc->zerosOdd[hc->prevBits] == INM_MAX_COUNT) {
+                scaleStats(hc);
             }
         }
     }
-    scaleEntropy();
-    scaleZeroOneCounts();
+    scaleEntropy(hc);
+    scaleZeroOneCounts(hc);
     return true;
 }
 
 // Once we have enough samples, we know that entropyPerBit = log(K)/log(2), so
 // K must be 2^entryopPerBit.
-double inmHealthCheckEstimateK(void) {
-    double entropyPerBit = (double)inmNumBitsOfEntropy/inmNumBitsSampled;
+double inmHealthCheckEstimateK(struct infnoise_health_state *hc) {
+    double entropyPerBit = (double)hc->numBitsOfEntropy/hc->numBitsSampled;
     return pow(2.0, entropyPerBit);
 }
 
 // Once we have enough samples, we know that entropyPerBit = log(K)/log(2), so
 // K must be 2^entryopPerBit.
-double inmHealthCheckEstimateEntropyPerBit(void) {
-    return (double)inmNumBitsOfEntropy/inmNumBitsSampled;
+double inmHealthCheckEstimateEntropyPerBit(struct infnoise_health_state *hc) {
+    return (double)hc->numBitsOfEntropy/hc->numBitsSampled;
 }
 
 // Return true if the health checker has enough data to verify proper operation of the INM.
-bool inmHealthCheckOkToUseData(void) {
-    double entropy = inmHealthCheckEstimateEntropyPerBit();
-    return inmTotalBits >= INM_MIN_DATA && entropy*INM_ACCURACY >= inmExpectedEntropyPerBit &&
-        entropy/INM_ACCURACY <= inmExpectedEntropyPerBit;
+bool inmHealthCheckOkToUseData(struct infnoise_health_state *hc) {
+    double entropy = inmHealthCheckEstimateEntropyPerBit(hc);
+    return hc->totalBits >= INM_MIN_DATA && entropy*INM_ACCURACY >= hc->expectedEntropyPerBit &&
+        entropy/INM_ACCURACY <= hc->expectedEntropyPerBit;
 }
 
 // Just return the entropy level added so far in bytes;
-uint32_t inmGetEntropyLevel(void) {
-    return inmEntropyLevel;
+uint32_t inmGetEntropyLevel(struct infnoise_health_state *hc) {
+    return hc->entropyLevel;
 }
 
 // Reduce the entropy level by numBytes.
-void inmClearEntropyLevel(void) {
-    inmEntropyLevel = 0u;
+void inmClearEntropyLevel(struct infnoise_health_state *hc) {
+    hc->entropyLevel = 0u;
 }
 
 // Check that the entropy of the last group of bits was high enough for use.
-bool inmEntropyOnTarget(uint32_t entropy, uint32_t numBits) {
-    uint32_t expectedEntropy = (uint32_t)(numBits*inmExpectedEntropyPerBit);
+bool inmEntropyOnTarget(struct infnoise_health_state *hc, uint32_t entropy, uint32_t numBits) {
+    uint32_t expectedEntropy = (uint32_t)(numBits*hc->expectedEntropyPerBit);
     return expectedEntropy < entropy*INM_ACCURACY;
 }
 
@@ -296,17 +280,17 @@ bool inmEntropyOnTarget(uint32_t entropy, uint32_t numBits) {
 #include "infnoise.h"
 
 // Compare the ability to predict with 1 fewer bits and see how much less accurate we are.
-static void checkLSBStatsForNBits(uint8_t N) {
+static void checkLSBStatsForNBits(struct infnoise_health_state *hc, uint8_t N) {
     uint32_t i, j;
     uint32_t totalGuesses = 0u;
     uint32_t totalRight = 0.0;
     for(i = 0u; i < (1u << N); i++) {
         uint32_t zeros = 0u;
         uint32_t ones = 0u;
-        for(j = 0u; j < (1u << (inmN - N)); j++) {
+        for(j = 0u; j < (1u << (hc->N - N)); j++) {
             uint32_t pos = i + j*(1u << N);
-            zeros += inmZerosEven[pos];
-            ones += inmOnesEven[pos];
+            zeros += hc->zerosEven[pos];
+            ones += hc->onesEven[pos];
         }
         if(zeros >= ones) {
             totalRight += zeros;
@@ -319,10 +303,10 @@ static void checkLSBStatsForNBits(uint8_t N) {
 }
 
 // Compare the ability to predict with 1 fewer bits and see how much less accurate we are.
-static void checkLSBStats(void) {
+static void checkLSBStats(struct infnoise_health_state *hc) {
     uint32_t N;
-    for(N = 1u; N <= inmN; N++) {
-        checkLSBStatsForNBits(N);
+    for(N = 1u; N <= hc->N; N++) {
+        checkLSBStatsForNBits(hc, N);
     }
 }
 
@@ -370,7 +354,9 @@ int main() {
     //double K = sqrt(2.0);
     double K = 1.82;
     uint8_t N = 16u;
-    inmHealthCheckStart(N, K, false);
+    struct infnoise_health_state hc;
+    memset(&hc, 0, sizeof(hc));
+    inmHealthCheckStart(&hc, N, K, false);
     srand(time(NULL));
     double A = (double)rand()/RAND_MAX; // Simulating INM
     double noiseAmplitude = 1.0/(1u << 10);
@@ -390,18 +376,18 @@ int main() {
         } else {
             oddBit = bit;
         }
-        if(!inmHealthCheckAddBit(evenBit, oddBit, even)) {
+        if(!inmHealthCheckAddBit(&hc, evenBit, oddBit, even)) {
             fprintf(stderr, "Failed health check!\n");
             return 1;
         }
-        if(inmTotalBits > 0u && (inmTotalBits & 0xfffffff) == 0) {
-            printf("Estimated entropy per bit: %f, estimated K: %f\n", inmHealthCheckEstimateEntropyPerBit(),
-                inmHealthCheckEstimateK());
-            checkLSBStats();
+        if(hc.totalBits > 0u && (hc.totalBits & 0xfffffff) == 0) {
+            printf("Estimated entropy per bit: %f, estimated K: %f\n", inmHealthCheckEstimateEntropyPerBit(&hc),
+                inmHealthCheckEstimateK(&hc));
+            checkLSBStats(&hc);
         }
     }
-    inmDumpStats();
-    inmHealthCheckStop();
+    inmDumpStats(&hc);
+    inmHealthCheckStop(&hc);
     return 0;
 }
 #endif

--- a/software/infnoise.c
+++ b/software/infnoise.c
@@ -311,13 +311,13 @@ int main(int argc, char **argv) {
     uint64_t totalBytesWritten = 0u;
     while (running) {
         uint8_t result[resultSize];
-        uint64_t bytesWritten = readData(&context, result, opts.raw, opts.outputMultiplier);
-        totalBytesWritten += bytesWritten;
-
-        if (context.errorFlag) {
+        int32_t rc = readData(&context, result, opts.raw, opts.outputMultiplier);
+        if (rc < 0) {
             fprintf(stderr, "Error: %s\n", context.message);
             return 1;
         }
+        uint32_t bytesWritten = (uint32_t)rc;
+        totalBytesWritten += bytesWritten;
 
         if (!opts.noOutput
             && !outputBytes(result, bytesWritten, context.entropyThisTime, opts.devRandom, opts.forceReseed, opts.feedFreq, &context.message)) {

--- a/software/libinfnoise.c
+++ b/software/libinfnoise.c
@@ -36,7 +36,6 @@ static void prepareOutputBuffer(struct infnoise_context *context) {
 bool initInfnoise(struct infnoise_context *context, char *serial, bool keccak, bool debug) {
     context->message="";
     context->entropyThisTime=0;
-    context->errorFlag=false;
     context->keccakBytesGiven=0;
 
     prepareOutputBuffer(context);
@@ -65,7 +64,6 @@ bool initInfnoise(struct infnoise_context *context, char *serial, bool keccak, b
     uint32_t maxWarmupRounds = 5000;
     uint32_t warmupRounds = 0;
 
-    //bool errorFlag = false;
     while (!inmHealthCheckOkToUseData(&context->health)) {
         readData(context, NULL, true, 1);
         warmupRounds++;
@@ -90,7 +88,7 @@ void deinitInfnoise(struct infnoise_context *context)
 // changes, not both, so alternate reading bits from them.  We get 1 INM bit of output
 // per byte read.  Feed bits from the INM to the health checker.  Return the expected
 // bits of entropy.
-uint32_t extractBytes(struct infnoise_context *context, uint8_t *bytes, uint32_t length, uint8_t *inBuf) {
+bool extractBytes(struct infnoise_context *context, uint8_t *bytes, uint32_t length, uint8_t *inBuf) {
     struct infnoise_health_state *hc = &context->health;
     inmClearEntropyLevel(hc);
     uint32_t i;
@@ -108,13 +106,13 @@ uint32_t extractBytes(struct infnoise_context *context, uint8_t *bytes, uint32_t
             // This is a good place to feed the bit from the INM to the health checker.
             if (!inmHealthCheckAddBit(hc, evenBit, oddBit, even)) {
                 context->message = "Health check of Infinite Noise Multiplier failed!";
-                context->errorFlag = true;
-                return 0;
+                return false;
             }
         }
         bytes[i] = byte;
     }
-    return inmGetEntropyLevel(hc);
+    context->entropyThisTime = inmGetEntropyLevel(hc);
+    return true;
 }
 
 
@@ -348,7 +346,7 @@ uint32_t processBytes(struct infnoise_context *context, uint8_t *bytes, uint8_t 
     return 0;
 }
 
-uint32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, uint32_t outputMultiplier) {
+int32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, uint32_t outputMultiplier) {
     // check if data can be squeezed from the keccak sponge from previous state (or we need to collect some new entropy to get bytesGiven >0)
     if (context->keccakBytesGiven == 0u) { // collect new entropy (e.g. case RAW)
         uint8_t inBuf[BUFLEN];
@@ -358,31 +356,28 @@ uint32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, u
         // write clock signal
         if (ftdi_write_data(&context->ftdic, context->outBuf, BUFLEN) != BUFLEN) {
             context->message = "USB write failed";
-            context->errorFlag = true;
+            return INFNOISE_ERR_USB_WRITE;
         }
 
         // and read 512 byte from the internal buffer (in synchronous bitbang mode)
         if (ftdi_read_data(&context->ftdic, inBuf, sizeof(inBuf)) != sizeof(inBuf)) {
             context->message = "USB read failed";
-            context->errorFlag = true;
-            return 0;
+            return INFNOISE_ERR_USB_READ;
         }
 
         clock_gettime(CLOCK_REALTIME, &end);
         if (diffTime(&start, &end) > MAX_MICROSEC_FOR_SAMPLES)
-            return 0;
+            return 0;  // transient — caller should retry
 
         uint8_t bytes[BUFLEN / 8u];
-        context->entropyThisTime = extractBytes(context, bytes, sizeof(bytes), inBuf);
-        if (context->errorFlag
-            || ! (inmHealthCheckOkToUseData(&context->health)
-                  && inmEntropyOnTarget(&context->health, context->entropyThisTime, BUFLEN)) ) {
-            // todo: message?
-            return 0;
-        }
+        if (!extractBytes(context, bytes, sizeof(bytes), inBuf))
+            return INFNOISE_ERR_HEALTH;
+        if (! (inmHealthCheckOkToUseData(&context->health)
+               && inmEntropyOnTarget(&context->health, context->entropyThisTime, BUFLEN)) )
+            return 0;  // transient — caller should retry
 
         // called health check are ok and return bytes
-        return processBytes(context, bytes, result, raw, outputMultiplier);
+        return (int32_t)processBytes(context, bytes, result, raw, outputMultiplier);
     } else { // squeeze the sponge!
 
         // Output up to 1024 bits at a time.
@@ -396,7 +391,7 @@ uint32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, u
         KeccakPermutation(context->keccakState);
 
         context->keccakBytesGiven -= bytesToWrite;
-        return bytesToWrite;
+        return (int32_t)bytesToWrite;
     }
     return 0;
 }

--- a/software/libinfnoise.c
+++ b/software/libinfnoise.c
@@ -22,17 +22,14 @@
 #include <fcntl.h>
 #endif
 
-uint8_t keccakState[KeccakPermutationSizeInBytes];
-uint8_t outBuf[BUFLEN];
-
-void prepareOutputBuffer() {
+static void prepareOutputBuffer(struct infnoise_context *context) {
     uint32_t i;
 
     // Endless loop: set SW1EN and SW2EN alternately
     for (i = 0u; i < BUFLEN; i+=2) {
         // Alternate Ph1 and Ph2
-        outBuf[i] = (1 << SWEN1);
-        outBuf[i+1] = (1 << SWEN2);
+        context->outBuf[i] = (1 << SWEN1);
+        context->outBuf[i+1] = (1 << SWEN2);
     }
 }
 
@@ -42,10 +39,10 @@ bool initInfnoise(struct infnoise_context *context, char *serial, bool keccak, b
     context->errorFlag=false;
     context->keccakBytesGiven=0;
 
-    prepareOutputBuffer();
+    prepareOutputBuffer(context);
 
     // initialize health check
-    if (!inmHealthCheckStart(PREDICTION_BITS, DESIGN_K, debug)) {
+    if (!inmHealthCheckStart(&context->health, PREDICTION_BITS, DESIGN_K, debug)) {
         context->message = "Can't initialize health checker";
         return false;
     }
@@ -61,7 +58,7 @@ bool initInfnoise(struct infnoise_context *context, char *serial, bool keccak, b
     // initialize keccak
     if (keccak) {
         KeccakInitialize();
-        KeccakInitializeState(keccakState);
+        KeccakInitializeState(context->keccakState);
     }
 
     // let healthcheck collect some data
@@ -69,7 +66,7 @@ bool initInfnoise(struct infnoise_context *context, char *serial, bool keccak, b
     uint32_t warmupRounds = 0;
 
     //bool errorFlag = false;
-    while (!inmHealthCheckOkToUseData()) {
+    while (!inmHealthCheckOkToUseData(&context->health)) {
         readData(context, NULL, true, 1);
         warmupRounds++;
     }
@@ -83,7 +80,7 @@ bool initInfnoise(struct infnoise_context *context, char *serial, bool keccak, b
 
 void deinitInfnoise(struct infnoise_context *context)
 {
-    inmHealthCheckStop();
+    inmHealthCheckStop(&context->health);
     ftdi_usb_close(&context->ftdic);
     ftdi_deinit(&context->ftdic);
 }
@@ -93,8 +90,9 @@ void deinitInfnoise(struct infnoise_context *context)
 // changes, not both, so alternate reading bits from them.  We get 1 INM bit of output
 // per byte read.  Feed bits from the INM to the health checker.  Return the expected
 // bits of entropy.
-uint32_t extractBytes(uint8_t *bytes, uint32_t length, uint8_t *inBuf, const char **message, bool *errorFlag) {
-    inmClearEntropyLevel();
+uint32_t extractBytes(struct infnoise_context *context, uint8_t *bytes, uint32_t length, uint8_t *inBuf) {
+    struct infnoise_health_state *hc = &context->health;
+    inmClearEntropyLevel(hc);
     uint32_t i;
     for (i = 0u; i < length; i++) {
         uint32_t j;
@@ -108,15 +106,15 @@ uint32_t extractBytes(uint8_t *bytes, uint32_t length, uint8_t *inBuf, const cha
             byte = (byte << 1u) | bit;
 
             // This is a good place to feed the bit from the INM to the health checker.
-            if (!inmHealthCheckAddBit(evenBit, oddBit, even)) {
-                *message = "Health check of Infinite Noise Multiplier failed!";
-                *errorFlag = true;
+            if (!inmHealthCheckAddBit(hc, evenBit, oddBit, even)) {
+                context->message = "Health check of Infinite Noise Multiplier failed!";
+                context->errorFlag = true;
                 return 0;
             }
         }
         bytes[i] = byte;
     }
-    return inmGetEntropyLevel();
+    return inmGetEntropyLevel(hc);
 }
 
 
@@ -290,13 +288,12 @@ bool initializeUSB(struct ftdi_context *ftdic, const char **message, char *seria
 // outputMultiplier is 0, we output only as many bits as we measure in entropy.
 // This allows a user to generate hundreds of MiB per second if needed, for use
 // as cryptographic keys.
-uint32_t processBytes(uint8_t *bytes, uint8_t *result, uint32_t *entropy,
-                      uint32_t *bytesGiven,
+uint32_t processBytes(struct infnoise_context *context, uint8_t *bytes, uint8_t *result,
                       bool raw, uint32_t outputMultiplier) {
     //Use the lower of the measured entropy and the provable lower bound on
     //average entropy.
-    if (*entropy > inmExpectedEntropyPerBit * BUFLEN / INM_ACCURACY) {
-        *entropy = inmExpectedEntropyPerBit * BUFLEN / INM_ACCURACY;
+    if (context->entropyThisTime > context->health.expectedEntropyPerBit * BUFLEN / INM_ACCURACY) {
+        context->entropyThisTime = context->health.expectedEntropyPerBit * BUFLEN / INM_ACCURACY;
     }
     if (raw) {
         // In raw mode, we just output raw data from the INM.
@@ -321,31 +318,31 @@ uint32_t processBytes(uint8_t *bytes, uint8_t *result, uint32_t *entropy,
     }
 
     uint8_t dataOut[resultSize];
-    KeccakAbsorb(keccakState, bytes, BUFLEN / 64u);
+    KeccakAbsorb(context->keccakState, bytes, BUFLEN / 64u);
 
     if (outputMultiplier == 0u) {
         // Output all the bytes of entropy we have
-        KeccakExtract(keccakState, dataOut, (*entropy + 63u) / 64u);
+        KeccakExtract(context->keccakState, dataOut, (context->entropyThisTime + 63u) / 64u);
         if (result != NULL) {
-            memcpy(result, dataOut, *entropy / 8u * sizeof(uint8_t));
+            memcpy(result, dataOut, context->entropyThisTime / 8u * sizeof(uint8_t));
         }
-        return *entropy / 8u;
+        return context->entropyThisTime / 8u;
     }
 
     // Output 256*outputMultipler bits (in chunks of 1024)
     // only the first 1024 now,
-    if (*bytesGiven == 0u) {
-        *bytesGiven = outputMultiplier*256u / 8u;
+    if (context->keccakBytesGiven == 0u) {
+        context->keccakBytesGiven = outputMultiplier*256u / 8u;
 
         // Output up to 1024 bits at a time.
         uint32_t bytesToWrite = 1024u / 8u;
-        if (bytesToWrite > *bytesGiven) {
-            bytesToWrite = *bytesGiven;
+        if (bytesToWrite > context->keccakBytesGiven) {
+            bytesToWrite = context->keccakBytesGiven;
         }
 
-        KeccakExtract(keccakState, result, bytesToWrite / 8u);
-        KeccakPermutation(keccakState);
-        *bytesGiven -= bytesToWrite;
+        KeccakExtract(context->keccakState, result, bytesToWrite / 8u);
+        KeccakPermutation(context->keccakState);
+        context->keccakBytesGiven -= bytesToWrite;
         return bytesToWrite;
     }
     return 0;
@@ -359,7 +356,7 @@ uint32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, u
         clock_gettime(CLOCK_REALTIME, &start);
 
         // write clock signal
-        if (ftdi_write_data(&context->ftdic, outBuf, sizeof(outBuf)) != sizeof(outBuf)) {
+        if (ftdi_write_data(&context->ftdic, context->outBuf, BUFLEN) != BUFLEN) {
             context->message = "USB write failed";
             context->errorFlag = true;
         }
@@ -376,16 +373,16 @@ uint32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, u
             return 0;
 
         uint8_t bytes[BUFLEN / 8u];
-        context->entropyThisTime = extractBytes(bytes, sizeof(bytes), inBuf, &context->message, &context->errorFlag);
+        context->entropyThisTime = extractBytes(context, bytes, sizeof(bytes), inBuf);
         if (context->errorFlag
-            || ! (inmHealthCheckOkToUseData() 
-                  && inmEntropyOnTarget(context->entropyThisTime, BUFLEN)) ) {
+            || ! (inmHealthCheckOkToUseData(&context->health)
+                  && inmEntropyOnTarget(&context->health, context->entropyThisTime, BUFLEN)) ) {
             // todo: message?
             return 0;
         }
 
         // called health check are ok and return bytes
-        return processBytes(bytes, result, &context->entropyThisTime, &context->keccakBytesGiven, raw, outputMultiplier);
+        return processBytes(context, bytes, result, raw, outputMultiplier);
     } else { // squeeze the sponge!
 
         // Output up to 1024 bits at a time.
@@ -395,8 +392,8 @@ uint32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, u
             bytesToWrite = context->keccakBytesGiven;
         }
 
-        KeccakExtract(keccakState, result, bytesToWrite / 8u);
-        KeccakPermutation(keccakState);
+        KeccakExtract(context->keccakState, result, bytesToWrite / 8u);
+        KeccakPermutation(context->keccakState);
 
         context->keccakBytesGiven -= bytesToWrite;
         return bytesToWrite;

--- a/software/libinfnoise.h
+++ b/software/libinfnoise.h
@@ -15,20 +15,64 @@
 // We also write this in one go to the Keccak sponge, which is at most 1600 bits
 #define BUFLEN 512u
 
+// KeccakPermutationSizeInBytes = 1600/8 = 200; avoid Keccak header dependency
+#define INFNOISE_KECCAK_STATE_SIZE 200
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #if !defined(_WIN32)
+
+// Health checker state — previously file-scope globals in healthcheck.c
+struct infnoise_health_state {
+    // Configuration (set once in inmHealthCheckStart)
+    uint8_t  N;
+    double   K;
+    double   expectedEntropyPerBit;
+    bool     debug;
+
+    // Dynamically allocated prediction tables
+    uint32_t *onesEven;
+    uint32_t *zerosEven;
+    uint32_t *onesOdd;
+    uint32_t *zerosOdd;
+
+    // Running state
+    uint32_t prevBits;
+    uint32_t numBitsSampled;
+    uint32_t numBitsOfEntropy;
+    double   currentProbability;
+    uint64_t totalBits;
+    bool     prevBit;
+    uint32_t entropyLevel;
+    uint32_t numSequentialZeros;
+    uint32_t numSequentialOnes;
+    uint32_t totalOnes;
+    uint32_t totalZeros;
+    uint32_t evenMisfires;
+    uint32_t oddMisfires;
+    bool     prevEven;
+    bool     prevOdd;
+};
+
 struct infnoise_context {
     struct ftdi_context ftdic;
     uint32_t entropyThisTime;
     const char *message;
     bool errorFlag;
-    //uint8_t keccakState[KeccakPermutationSizeInBytes];
 
     // used in multiplier mode to keep track of bytes to be put out
     uint32_t keccakBytesGiven;
+
+    // Keccak sponge state — previously global in libinfnoise.c
+    uint8_t keccakState[INFNOISE_KECCAK_STATE_SIZE];
+
+    // USB clock signal buffer — previously global in libinfnoise.c
+    uint8_t outBuf[BUFLEN];
+
+    // Health checker — previously static globals in healthcheck.c
+    struct infnoise_health_state health;
 };
 
 typedef struct _infnoise_devlist_node_t infnoise_devlist_node_t;

--- a/software/libinfnoise.h
+++ b/software/libinfnoise.h
@@ -22,6 +22,21 @@
 extern "C" {
 #endif
 
+// Machine-readable error codes for readData and initInfnoise.
+// Negative values are fatal errors; zero is transient (retry); positive is success.
+typedef enum {
+    INFNOISE_OK              =  0,
+    INFNOISE_ERR_USB_WRITE   = -1,
+    INFNOISE_ERR_USB_READ    = -2,
+    INFNOISE_ERR_HEALTH      = -3,
+    INFNOISE_ERR_TIMING      = -4,
+    INFNOISE_ERR_ENTROPY     = -5,
+    INFNOISE_ERR_NOT_FOUND   = -6,
+    INFNOISE_ERR_INIT        = -7,
+    INFNOISE_ERR_USB_BAUD    = -8,
+    INFNOISE_ERR_USB_BITMODE = -9,
+} infnoise_error_t;
+
 #if !defined(_WIN32)
 
 // Health checker state — previously file-scope globals in healthcheck.c
@@ -60,7 +75,6 @@ struct infnoise_context {
     struct ftdi_context ftdic;
     uint32_t entropyThisTime;
     const char *message;
-    bool errorFlag;
 
     // used in multiplier mode to keep track of bytes to be put out
     uint32_t keccakBytesGiven;
@@ -116,23 +130,23 @@ void deinitInfnoise(struct infnoise_context *context);
 
 /*
  * Reads some bytes from the TRNG and stores them in the "result" byte array.
- * The array has to be of sufficient size. Please refer to the example programs. 
+ * The array has to be of sufficient size. Please refer to the example programs.
  * (64 byte for normal operation or 128byte for multiplier mode)
  *
- * After every read operation, the infnoise_context's errorFlag must be checked,
- * and the data from this call has to be discarded when it returns true!
+ * Return value:
+ *   > 0: number of bytes written to result
+ *     0: transient condition (timing exceeded, entropy off-target) — retry
+ *   < 0: fatal error (infnoise_error_t code) — check context->message
  *
- * Detailed error messages can then be found in context->message.
+ * context->message is set with a human-readable diagnostic on error.
  *
  * parameters:
  *  - context: infnoise_context struct with device pointer and state variables
  *  - result: pointer to byte array to store the result
  *  - raw: boolean flag for raw or whitened output
  *  - outputMultiplier: only used for whitened output
- *
- * returns: number of bytes written to the byte-array
 */
-uint32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, uint32_t outputMultiplier);
+int32_t readData(struct infnoise_context *context, uint8_t *result, bool raw, uint32_t outputMultiplier);
 
 #ifdef __cplusplus
 }

--- a/software/libinfnoise_private.h
+++ b/software/libinfnoise_private.h
@@ -63,7 +63,7 @@ bool initializeUSB(struct ftdi_context *ftdic, const char **message, char *seria
 
 struct timespec;
 double diffTime(struct timespec *start, struct timespec *end);
-uint32_t extractBytes(struct infnoise_context *context, uint8_t *bytes, uint32_t length, uint8_t *inBuf);
+bool extractBytes(struct infnoise_context *context, uint8_t *bytes, uint32_t length, uint8_t *inBuf);
 uint32_t processBytes(struct infnoise_context *context, uint8_t *bytes, uint8_t *result, bool raw, uint32_t outputMultiplier);
 
 bool outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, bool writeDevRandom, const char **message);

--- a/software/libinfnoise_private.h
+++ b/software/libinfnoise_private.h
@@ -45,27 +45,26 @@
 // All data bus bits of the FT240X are outputs, except COMP1 and COMP2
 #define MASK (0xffu & ~(1u << COMP1) & ~(1u << COMP2))
 
-bool inmHealthCheckStart(uint8_t N, double K, bool debug);
-void inmHealthCheckStop(void);
-bool inmHealthCheckAddBit(bool evenBit, bool oddBit, bool even);
-bool inmHealthCheckOkToUseData(void);
-double inmHealthCheckEstimateK(void);
-double inmHealthCheckEstimateEntropyPerBit(void);
-uint32_t inmGetEntropyLevel(void);
-void inmClearEntropyLevel(void);
-bool inmEntropyOnTarget(uint32_t entropy, uint32_t bits);
+bool inmHealthCheckStart(struct infnoise_health_state *hc, uint8_t N, double K, bool debug);
+void inmHealthCheckStop(struct infnoise_health_state *hc);
+bool inmHealthCheckAddBit(struct infnoise_health_state *hc, bool evenBit, bool oddBit, bool even);
+bool inmHealthCheckOkToUseData(struct infnoise_health_state *hc);
+double inmHealthCheckEstimateK(struct infnoise_health_state *hc);
+double inmHealthCheckEstimateEntropyPerBit(struct infnoise_health_state *hc);
+uint32_t inmGetEntropyLevel(struct infnoise_health_state *hc);
+void inmClearEntropyLevel(struct infnoise_health_state *hc);
+bool inmEntropyOnTarget(struct infnoise_health_state *hc, uint32_t entropy, uint32_t bits);
 
-void inmDumpStats(void);
-
-extern double inmK, inmExpectedEntropyPerBit;
+void inmDumpStats(struct infnoise_health_state *hc);
 
 #if !defined(_WIN32)
 
-bool initializeUSB(struct ftdi_context *ftdic, const char **message,char *serial);
+bool initializeUSB(struct ftdi_context *ftdic, const char **message, char *serial);
 
 struct timespec;
 double diffTime(struct timespec *start, struct timespec *end);
-uint32_t extractBytes(uint8_t *bytes, uint32_t length, uint8_t *inBuf, const char **message, bool *errorFlag);
+uint32_t extractBytes(struct infnoise_context *context, uint8_t *bytes, uint32_t length, uint8_t *inBuf);
+uint32_t processBytes(struct infnoise_context *context, uint8_t *bytes, uint8_t *result, bool raw, uint32_t outputMultiplier);
 
 bool outputBytes(uint8_t *bytes, uint32_t length, uint32_t entropy, bool writeDevRandom, const char **message);
 


### PR DESCRIPTION
Add `infnoise_error_t` enum. Change `readData()` from `uint32_t` to `int32_t`:

  > 0  bytes written
    0  transient (timing/entropy) — retry
  < 0  fatal, value is an infnoise_error_t

Drop `errorFlag` from the context. Return value is the single source of
truth; message stays for human-readable diagnostics.

`extractBytes` (internal) now returns bool and writes entropy directly
into `context->entropyThisTime` instead of signaling via `errorFlag`.

Fixes a real bug: USB write failure set `errorFlag` but didn't return,
falling through to the USB read.

Stacked on #121, need to merge that first.

Tested: builds clean with `-Wall -Wextra -Werror`, CLI and both examples
updated.

Co-Authored-By: Claude Opus