### PR TITLE
kmod: handle FT240X bulk transfers correctly

### DIFF
--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -70,6 +70,11 @@
 
 /* FTDI interface index (1-based: interface 0 uses index 1) */
 #define FTDI_INDEX_INTERFACE_A	1
+/* FTDI baudrate request encodes interface A as zero. */
+#define FTDI_INDEX_BAUDRATE_A	0
+
+#define FTDI_BAUDRATE_9600	0x4138
+#define FTDI_BAUDRATE_30000	0x0064
 
 /* Buffer sizes */
 #define INFNOISE_BUFLEN		512	/* FT240X buffer size, must be multiple of 64 */
@@ -78,9 +83,8 @@
 /* FTDI packet format: each 64-byte USB packet has 2 status bytes + 62 data bytes */
 #define FTDI_PACKET_SIZE	64
 #define FTDI_STATUS_SIZE	2
-#define FTDI_DATA_PER_PACKET	(FTDI_PACKET_SIZE - FTDI_STATUS_SIZE)  /* 62 */
-/* For 512 bytes of data, we need ceil(512/62) = 9 packets = 576 bytes */
-#define INFNOISE_USB_READ_SIZE	(((INFNOISE_BUFLEN + FTDI_DATA_PER_PACKET - 1) / FTDI_DATA_PER_PACKET) * FTDI_PACKET_SIZE)
+/* Match libftdi's default bulk IN chunk; one transfer can contain many packets. */
+#define INFNOISE_USB_READ_SIZE	4096
 
 /* Health check constants */
 #define INM_PREDICTION_BITS	14	/* Bits used for prediction */
@@ -212,7 +216,7 @@ struct infnoise_device {
 
 	/* Buffers */
 	u8 *clock_buf;		/* Clock pattern buffer (512 bytes) */
-	u8 *usb_buf;		/* Raw USB read buffer (576 bytes w/ FTDI status) */
+	u8 *usb_buf;		/* Raw FTDI USB transfer buffer (4096 bytes) */
 	u8 *read_buf;		/* Processed read buffer (512 bytes, status stripped) */
 	u8 *out_buf;		/* Output buffer (64 bytes) */
 

--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -78,9 +78,8 @@
 /* FTDI packet format: each 64-byte USB packet has 2 status bytes + 62 data bytes */
 #define FTDI_PACKET_SIZE	64
 #define FTDI_STATUS_SIZE	2
-#define FTDI_DATA_PER_PACKET	(FTDI_PACKET_SIZE - FTDI_STATUS_SIZE)  /* 62 */
-/* For 512 bytes of data, we need ceil(512/62) = 9 packets = 576 bytes */
-#define INFNOISE_USB_READ_SIZE	(((INFNOISE_BUFLEN + FTDI_DATA_PER_PACKET - 1) / FTDI_DATA_PER_PACKET) * FTDI_PACKET_SIZE)
+/* Match libftdi's default bulk IN chunk; one transfer can contain many packets. */
+#define INFNOISE_USB_READ_SIZE	4096
 
 /* Health check constants */
 #define INM_PREDICTION_BITS	14	/* Bits used for prediction */
@@ -212,7 +211,7 @@ struct infnoise_device {
 
 	/* Buffers */
 	u8 *clock_buf;		/* Clock pattern buffer (512 bytes) */
-	u8 *usb_buf;		/* Raw USB read buffer (576 bytes w/ FTDI status) */
+	u8 *usb_buf;		/* Raw FTDI USB transfer buffer (4096 bytes) */
 	u8 *read_buf;		/* Processed read buffer (512 bytes, status stripped) */
 	u8 *out_buf;		/* Output buffer (64 bytes) */
 

--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -70,11 +70,6 @@
 
 /* FTDI interface index (1-based: interface 0 uses index 1) */
 #define FTDI_INDEX_INTERFACE_A	1
-/* FTDI baudrate request encodes interface A as zero. */
-#define FTDI_INDEX_BAUDRATE_A	0
-
-#define FTDI_BAUDRATE_9600	0x4138
-#define FTDI_BAUDRATE_30000	0x0064
 
 /* Buffer sizes */
 #define INFNOISE_BUFLEN		512	/* FT240X buffer size, must be multiple of 64 */
@@ -83,8 +78,9 @@
 /* FTDI packet format: each 64-byte USB packet has 2 status bytes + 62 data bytes */
 #define FTDI_PACKET_SIZE	64
 #define FTDI_STATUS_SIZE	2
-/* Match libftdi's default bulk IN chunk; one transfer can contain many packets. */
-#define INFNOISE_USB_READ_SIZE	4096
+#define FTDI_DATA_PER_PACKET	(FTDI_PACKET_SIZE - FTDI_STATUS_SIZE)  /* 62 */
+/* For 512 bytes of data, we need ceil(512/62) = 9 packets = 576 bytes */
+#define INFNOISE_USB_READ_SIZE	(((INFNOISE_BUFLEN + FTDI_DATA_PER_PACKET - 1) / FTDI_DATA_PER_PACKET) * FTDI_PACKET_SIZE)
 
 /* Health check constants */
 #define INM_PREDICTION_BITS	14	/* Bits used for prediction */
@@ -216,7 +212,7 @@ struct infnoise_device {
 
 	/* Buffers */
 	u8 *clock_buf;		/* Clock pattern buffer (512 bytes) */
-	u8 *usb_buf;		/* Raw FTDI USB transfer buffer (4096 bytes) */
+	u8 *usb_buf;		/* Raw USB read buffer (576 bytes w/ FTDI status) */
 	u8 *read_buf;		/* Processed read buffer (512 bytes, status stripped) */
 	u8 *out_buf;		/* Output buffer (64 bytes) */
 

--- a/software/kernel/infnoise.h
+++ b/software/kernel/infnoise.h
@@ -70,6 +70,11 @@
 
 /* FTDI interface index (1-based: interface 0 uses index 1) */
 #define FTDI_INDEX_INTERFACE_A	1
+/* FTDI baudrate request encodes interface A as zero. */
+#define FTDI_INDEX_BAUDRATE_A	0
+
+#define FTDI_BAUDRATE_9600	0x4138
+#define FTDI_BAUDRATE_30000	0x0064
 
 /* Buffer sizes */
 #define INFNOISE_BUFLEN		512	/* FT240X buffer size, must be multiple of 64 */

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -435,6 +435,20 @@ static int infnoise_usb_transfer(struct infnoise_device *dev)
 			return ret;
 		}
 
+		/* Discard any partial batch before issuing a new set of clocks. */
+		if (retry + 1 < INFNOISE_MAX_RETRIES) {
+			int purge_ret;
+
+			purge_ret = ftdi_control(dev, FTDI_SIO_RESET,
+						 FTDI_SIO_RESET_PURGE_RX,
+						 FTDI_INDEX_INTERFACE_A);
+			if (purge_ret < 0) {
+				dev_warn(&dev->intf->dev,
+					 "Failed to purge RX before retry: %d\n", purge_ret);
+				return purge_ret;
+			}
+		}
+
 		/* Attempt recovery if we've hit the threshold */
 		if (dev->consecutive_errors >= INFNOISE_RECOVERY_THRESHOLD) {
 			int recovery_ret = infnoise_try_recovery(dev);

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -95,13 +95,16 @@ static int infnoise_configure_ftdi(struct infnoise_device *dev)
 		return ret;
 	}
 
-	/*
-	 * Set baud rate to 30000
-	 * FTDI baud rate encoding: value = 3000000 / baud
-	 * For 30000 baud: value = 100 = 0x0064
-	 */
-	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, 0x0064,
-			   FTDI_INDEX_INTERFACE_A);
+	/* Match the control-transfer sequence captured from libftdi. */
+	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, FTDI_BAUDRATE_9600,
+			   FTDI_INDEX_BAUDRATE_A);
+	if (ret < 0) {
+		dev_err(&dev->intf->dev, "Failed to set default baud rate: %d\n", ret);
+		return ret;
+	}
+
+	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, FTDI_BAUDRATE_30000,
+			   FTDI_INDEX_BAUDRATE_A);
 	if (ret < 0) {
 		dev_err(&dev->intf->dev, "Failed to set baud rate: %d\n", ret);
 		return ret;

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -55,6 +55,8 @@ static void infnoise_warmup_work(struct work_struct *work);
 static int infnoise_read_data(struct infnoise_device *dev, u8 *result,
 			      size_t max_len, bool raw);
 static int infnoise_configure_ftdi(struct infnoise_device *dev);
+static int infnoise_read_samples(struct infnoise_device *dev, int target,
+				 int *data_bytes, unsigned long deadline);
 
 /*
  * FTDI USB control transfer helper
@@ -137,53 +139,6 @@ static int infnoise_configure_ftdi(struct infnoise_device *dev)
 	/* Give the device time to settle after configuration */
 	msleep(50);
 
-	return 0;
-}
-
-/*
- * Test USB transfer to verify device is working
- * Similar to what libftdi does during initialization
- */
-static int infnoise_test_transfer(struct infnoise_device *dev)
-{
-	u8 *test_buf;
-	int ret, actual;
-
-	/* Allocate DMA-capable buffer */
-	test_buf = kmalloc(64, GFP_KERNEL);
-	if (!test_buf)
-		return -ENOMEM;
-
-	memset(test_buf, 0, 64);
-
-	/* Clear any halt condition on endpoints */
-	usb_clear_halt(dev->udev, usb_sndbulkpipe(dev->udev, dev->bulk_out_ep));
-	usb_clear_halt(dev->udev, usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep));
-
-	/* Test write */
-	ret = usb_bulk_msg(dev->udev,
-			   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
-			   test_buf, 64,
-			   &actual, INFNOISE_USB_TIMEOUT);
-	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Test write failed: %d\n", ret);
-		kfree(test_buf);
-		return ret;
-	}
-
-	/* Test read */
-	ret = usb_bulk_msg(dev->udev,
-			   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
-			   test_buf, 64,
-			   &actual, INFNOISE_USB_TIMEOUT);
-	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Test read failed: %d\n", ret);
-		kfree(test_buf);
-		return ret;
-	}
-
-	dev_info(&dev->intf->dev, "Test transfer OK (%d bytes)\n", actual);
-	kfree(test_buf);
 	return 0;
 }
 
@@ -323,6 +278,32 @@ static int infnoise_write_clocks(struct infnoise_device *dev, const u8 *clocks,
 		return -EIO;
 
 	return 0;
+}
+
+/*
+ * Complete the initial synchronous bit-bang exchange before warmup consumes
+ * samples. A short FTDI packet includes status bytes and is not sufficient.
+ */
+static int infnoise_prime_ftdi(struct infnoise_device *dev)
+{
+	int data_bytes = 0;
+	int ret;
+	unsigned long deadline;
+
+	/* read_buf is heap allocated and therefore valid for USB DMA. */
+	memset(dev->read_buf, 0, FTDI_PACKET_SIZE);
+	ret = infnoise_write_clocks(dev, dev->read_buf, FTDI_PACKET_SIZE);
+	if (ret) {
+		dev_err(&dev->intf->dev, "Initial FTDI write failed: %d\n", ret);
+		return ret;
+	}
+
+	deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
+	ret = infnoise_read_samples(dev, FTDI_PACKET_SIZE, &data_bytes, deadline);
+	if (ret)
+		dev_err(&dev->intf->dev, "Initial FTDI read failed: %d\n", ret);
+
+	return ret;
 }
 
 /*
@@ -602,15 +583,24 @@ static void infnoise_warmup_work(struct work_struct *work)
 						   warmup_work);
 	unsigned int rounds = 0;
 	u8 discard[64];
+	int ret = 0;
 
 	dev_info(&dev->intf->dev, "Starting warmup...\n");
 
-	mutex_lock(&dev->lock);
+	/* Run bulk I/O after probe has returned and the endpoint is ready. */
+	msleep(100);
+	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
+		return;
 
-	while (!infnoise_health_ok(&dev->health) &&
+	mutex_lock(&dev->lock);
+	ret = infnoise_prime_ftdi(dev);
+
+	while (!ret && !infnoise_health_ok(&dev->health) &&
 	       rounds < INFNOISE_WARMUP_ROUNDS &&
 	       test_bit(INFNOISE_PRESENT, &dev->flags)) {
-		infnoise_read_data(dev, discard, sizeof(discard), true);
+		ret = infnoise_read_data(dev, discard, sizeof(discard), true);
+		if (ret < 0)
+			break;
 		rounds++;
 	}
 
@@ -621,7 +611,10 @@ static void infnoise_warmup_work(struct work_struct *work)
 		return;
 	}
 
-	if (rounds >= INFNOISE_WARMUP_ROUNDS) {
+	if (ret < 0) {
+		dev_err(&dev->intf->dev, "Warmup stopped after USB error: %d\n", ret);
+		set_bit(INFNOISE_HEALTH_FAIL, &dev->flags);
+	} else if (rounds >= INFNOISE_WARMUP_ROUNDS) {
 		dev_err(&dev->intf->dev,
 			"Warmup failed after %u rounds\n", rounds);
 		set_bit(INFNOISE_HEALTH_FAIL, &dev->flags);
@@ -913,11 +906,6 @@ static int infnoise_probe(struct usb_interface *intf,
 
 	/* Configure FTDI */
 	ret = infnoise_configure_ftdi(dev);
-	if (ret)
-		goto err_health;
-
-	/* Test transfer to prime the device */
-	ret = infnoise_test_transfer(dev);
 	if (ret)
 		goto err_health;
 

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -87,14 +87,6 @@ static int infnoise_configure_ftdi(struct infnoise_device *dev)
 		return ret;
 	}
 
-	/* Set latency timer to 1ms for faster response */
-	ret = ftdi_control(dev, FTDI_SIO_SET_LATENCY_TIMER, 1,
-			   FTDI_INDEX_INTERFACE_A);
-	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Failed to set latency timer: %d\n", ret);
-		return ret;
-	}
-
 	/* Match the control-transfer sequence captured from libftdi. */
 	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, FTDI_BAUDRATE_9600,
 			   FTDI_INDEX_BAUDRATE_A);

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -85,21 +85,16 @@ static int infnoise_configure_ftdi(struct infnoise_device *dev)
 		return ret;
 	}
 
-	/* Set latency timer to 1ms for faster response */
-	ret = ftdi_control(dev, FTDI_SIO_SET_LATENCY_TIMER, 1,
-			   FTDI_INDEX_INTERFACE_A);
+	/* Match libftdi: configure its default baudrate before the target rate. */
+	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, FTDI_BAUDRATE_9600,
+			   FTDI_INDEX_BAUDRATE_A);
 	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Failed to set latency timer: %d\n", ret);
+		dev_err(&dev->intf->dev, "Failed to set default baud rate: %d\n", ret);
 		return ret;
 	}
 
-	/*
-	 * Set baud rate to 30000
-	 * FTDI baud rate encoding: value = 3000000 / baud
-	 * For 30000 baud: value = 100 = 0x0064
-	 */
-	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, 0x0064,
-			   FTDI_INDEX_INTERFACE_A);
+	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, FTDI_BAUDRATE_30000,
+			   FTDI_INDEX_BAUDRATE_A);
 	if (ret < 0) {
 		dev_err(&dev->intf->dev, "Failed to set baud rate: %d\n", ret);
 		return ret;
@@ -118,72 +113,10 @@ static int infnoise_configure_ftdi(struct infnoise_device *dev)
 		return ret;
 	}
 
-	/* Purge RX buffer */
-	ret = ftdi_control(dev, FTDI_SIO_RESET, FTDI_SIO_RESET_PURGE_RX,
-			   FTDI_INDEX_INTERFACE_A);
-	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Failed to purge RX: %d\n", ret);
-		return ret;
-	}
-
-	/* Purge TX buffer */
-	ret = ftdi_control(dev, FTDI_SIO_RESET, FTDI_SIO_RESET_PURGE_TX,
-			   FTDI_INDEX_INTERFACE_A);
-	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Failed to purge TX: %d\n", ret);
-		return ret;
-	}
-
-	/* Give the device time to settle after configuration */
+	/* The USB interface has just been bound; let SYNCBB settle before its
+	 * first bulk URB is queued from probe context. */
 	msleep(50);
 
-	return 0;
-}
-
-/*
- * Test USB transfer to verify device is working
- * Similar to what libftdi does during initialization
- */
-static int infnoise_test_transfer(struct infnoise_device *dev)
-{
-	u8 *test_buf;
-	int ret, actual;
-
-	/* Allocate DMA-capable buffer */
-	test_buf = kmalloc(64, GFP_KERNEL);
-	if (!test_buf)
-		return -ENOMEM;
-
-	memset(test_buf, 0, 64);
-
-	/* Clear any halt condition on endpoints */
-	usb_clear_halt(dev->udev, usb_sndbulkpipe(dev->udev, dev->bulk_out_ep));
-	usb_clear_halt(dev->udev, usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep));
-
-	/* Test write */
-	ret = usb_bulk_msg(dev->udev,
-			   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
-			   test_buf, 64,
-			   &actual, INFNOISE_USB_TIMEOUT);
-	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Test write failed: %d\n", ret);
-		kfree(test_buf);
-		return ret;
-	}
-
-	/* Test read */
-	ret = usb_bulk_msg(dev->udev,
-			   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
-			   test_buf, 64,
-			   &actual, INFNOISE_USB_TIMEOUT);
-	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Test read failed: %d\n", ret);
-		kfree(test_buf);
-		return ret;
-	}
-
-	dev_info(&dev->intf->dev, "Test transfer OK (%d bytes)\n", actual);
-	kfree(test_buf);
 	return 0;
 }
 
@@ -297,42 +230,110 @@ static int infnoise_extract_bytes(struct infnoise_device *dev, u8 *bytes,
 	return infnoise_health_get_entropy(&dev->health);
 }
 
-/*
- * Strip FTDI modem status bytes from USB data
- *
- * FTDI sends data in 64-byte packets: 2 status bytes + 62 data bytes.
- * This function extracts just the data bytes.
- */
-static int infnoise_strip_ftdi_status(struct infnoise_device *dev,
-				      int usb_bytes)
+/* Retry transient host-controller backpressure for a bounded interval. */
+static int infnoise_write_clocks(struct infnoise_device *dev, const u8 *clocks,
+					 size_t length)
 {
-	int packets = usb_bytes / FTDI_PACKET_SIZE;
-	int leftover = usb_bytes % FTDI_PACKET_SIZE;
-	int data_bytes = 0;
-	int i;
+	unsigned long deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
+	int actual;
+	int ret;
 
-	for (i = 0; i < packets; i++) {
-		u8 *src = dev->usb_buf + i * FTDI_PACKET_SIZE + FTDI_STATUS_SIZE;
-		int copy_len = min(FTDI_DATA_PER_PACKET,
-				   INFNOISE_BUFLEN - data_bytes);
+	for (;;) {
+		ret = usb_bulk_msg(dev->udev,
+				   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
+				   (void *)clocks, length, &actual,
+				   INFNOISE_USB_TIMEOUT);
+		if (ret != -EAGAIN && !(ret == 0 && actual == 0))
+			break;
+		if (time_after_eq(jiffies, deadline))
+			return -ETIMEDOUT;
+		usleep_range(1000, 2000);
+	}
 
-		if (copy_len > 0) {
-			memcpy(dev->read_buf + data_bytes, src, copy_len);
-			data_bytes += copy_len;
+	if (ret < 0)
+		return ret;
+	if (actual != length)
+		return -EIO;
+
+	return 0;
+}
+
+/*
+ * Read FTDI packets until the requested number of sample bytes is available.
+ * A bulk transfer can contain several 64-byte FTDI packets; remove the two
+ * status bytes at the beginning of each packet before consuming samples.
+ */
+static int infnoise_read_samples(struct infnoise_device *dev, int target,
+				 int *data_bytes, unsigned long deadline)
+{
+	int ret;
+	int actual;
+
+	while (*data_bytes < target) {
+		u8 *pkt = dev->usb_buf;
+		int offset;
+
+		ret = usb_bulk_msg(dev->udev,
+				   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
+				   pkt, INFNOISE_USB_READ_SIZE, &actual,
+				   INFNOISE_USB_TIMEOUT);
+		/* The host controller can transiently reject an URB with -EAGAIN. */
+		if (ret == -ETIMEDOUT || ret == -EAGAIN ||
+		    (ret == 0 && actual == 0)) {
+			if (time_after_eq(jiffies, deadline))
+				return -ETIMEDOUT;
+			usleep_range(100, 200);
+			continue;
+		}
+		if (ret < 0) {
+			if (infnoise_debug)
+				dev_dbg(&dev->intf->dev, "USB read failed: %d\n", ret);
+			return ret;
+		}
+
+		for (offset = 0; offset < actual && *data_bytes < target;) {
+			int packet_len = min(FTDI_PACKET_SIZE, actual - offset);
+			int payload;
+
+			if (packet_len > FTDI_STATUS_SIZE) {
+				payload = min(packet_len - FTDI_STATUS_SIZE,
+					      target - *data_bytes);
+				memcpy(dev->read_buf + *data_bytes,
+				       pkt + offset + FTDI_STATUS_SIZE, payload);
+				*data_bytes += payload;
+			}
+			offset += packet_len;
 		}
 	}
 
-	/* Handle partial packet at end if any */
-	if (leftover > FTDI_STATUS_SIZE && data_bytes < INFNOISE_BUFLEN) {
-		int copy_len = min(leftover - FTDI_STATUS_SIZE,
-				   INFNOISE_BUFLEN - data_bytes);
-		u8 *src = dev->usb_buf + packets * FTDI_PACKET_SIZE + FTDI_STATUS_SIZE;
+	return 0;
+}
 
-		memcpy(dev->read_buf + data_bytes, src, copy_len);
-		data_bytes += copy_len;
+/*
+ * libftdi verifies a newly configured interface with a 64-byte synchronous
+ * bit-bang exchange. A USB short packet contains FTDI status bytes, so read
+ * all 64 sample bytes before considering the exchange complete.
+ */
+static int infnoise_prime_ftdi(struct infnoise_device *dev)
+{
+	int data_bytes = 0;
+	int ret;
+	unsigned long deadline;
+
+	/* read_buf is heap allocated and therefore valid for USB DMA. */
+	memset(dev->read_buf, 0, FTDI_PACKET_SIZE);
+	ret = infnoise_write_clocks(dev, dev->read_buf, FTDI_PACKET_SIZE);
+	if (ret) {
+		dev_err(&dev->intf->dev, "Initial FTDI write failed: %d\n", ret);
+		return ret;
 	}
 
-	return data_bytes;
+	deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
+	ret = infnoise_read_samples(dev, FTDI_PACKET_SIZE, &data_bytes, deadline);
+	if (ret)
+		dev_err(&dev->intf->dev, "Initial FTDI read failed: %d\n", ret);
+
+	return ret;
 }
 
 /*
@@ -344,66 +345,24 @@ static int infnoise_strip_ftdi_status(struct infnoise_device *dev,
 static int infnoise_usb_transfer_once(struct infnoise_device *dev)
 {
 	int ret;
-	int actual;
-	int total_read = 0;
-	int data_bytes;
+	int data_bytes = 0;
+	unsigned long deadline;
 
-	/* Write clock pattern */
-	ret = usb_bulk_msg(dev->udev,
-			   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
-			   dev->clock_buf, INFNOISE_BUFLEN,
-			   &actual, INFNOISE_USB_TIMEOUT);
-	if (ret < 0) {
+	/*
+	 * SYNCBB returns one sample for each clock byte. Match the userspace
+	 * driver by queueing the complete 512-byte clock batch before reading.
+	 */
+	ret = infnoise_write_clocks(dev, dev->clock_buf, INFNOISE_BUFLEN);
+	if (ret) {
 		if (infnoise_debug)
 			dev_dbg(&dev->intf->dev, "USB write failed: %d\n", ret);
 		return ret;
 	}
 
-	if (actual != INFNOISE_BUFLEN) {
-		dev_err(&dev->intf->dev, "Short write: %d/%d\n",
-			actual, INFNOISE_BUFLEN);
-		return -EIO;
-	}
-
-	/*
-	 * Read samples - FTDI returns data in 64-byte packets with 2 status
-	 * bytes per packet. We need to read until we have enough data bytes.
-	 */
-	while (total_read < INFNOISE_USB_READ_SIZE) {
-		int remaining = INFNOISE_USB_READ_SIZE - total_read;
-
-		ret = usb_bulk_msg(dev->udev,
-				   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
-				   dev->usb_buf + total_read, remaining,
-				   &actual, INFNOISE_USB_TIMEOUT);
-		if (ret < 0) {
-			if (infnoise_debug)
-				dev_dbg(&dev->intf->dev, "USB read failed: %d\n", ret);
-			return ret;
-		}
-
-		if (actual == 0) {
-			if (infnoise_debug)
-				dev_dbg(&dev->intf->dev, "USB read timeout, got %d/%d\n",
-					total_read, INFNOISE_USB_READ_SIZE);
-			return -ETIMEDOUT;
-		}
-
-		total_read += actual;
-
-		if (infnoise_debug && total_read < INFNOISE_USB_READ_SIZE)
-			dev_dbg(&dev->intf->dev, "Partial read: %d/%d, continuing\n",
-				total_read, INFNOISE_USB_READ_SIZE);
-	}
-
-	/* Strip FTDI status bytes to get actual data */
-	data_bytes = infnoise_strip_ftdi_status(dev, total_read);
-
-	if (data_bytes < INFNOISE_BUFLEN) {
-		dev_err(&dev->intf->dev, "Short data: %d/%d bytes\n",
-			data_bytes, INFNOISE_BUFLEN);
-		return -EIO;
-	}
+	deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
+	ret = infnoise_read_samples(dev, INFNOISE_BUFLEN, &data_bytes, deadline);
+	if (ret)
+		return ret;
 
 	/* Extract entropy bits */
 	return infnoise_extract_bytes(dev, dev->out_buf, INFNOISE_BYTES_OUT,
@@ -463,6 +422,20 @@ static int infnoise_usb_transfer(struct infnoise_device *dev)
 				dev_dbg(&dev->intf->dev,
 					"Non-recoverable error: %d\n", ret);
 			return ret;
+		}
+
+		/* Discard any partial batch before issuing a new set of clocks. */
+		if (retry + 1 < INFNOISE_MAX_RETRIES) {
+			int purge_ret;
+
+			purge_ret = ftdi_control(dev, FTDI_SIO_RESET,
+						 FTDI_SIO_RESET_PURGE_RX,
+						 FTDI_INDEX_INTERFACE_A);
+			if (purge_ret < 0) {
+				dev_warn(&dev->intf->dev,
+					 "Failed to purge RX before retry: %d\n", purge_ret);
+				return purge_ret;
+			}
 		}
 
 		/* Attempt recovery if we've hit the threshold */
@@ -608,15 +581,24 @@ static void infnoise_warmup_work(struct work_struct *work)
 						   warmup_work);
 	unsigned int rounds = 0;
 	u8 discard[64];
+	int ret = 0;
 
 	dev_info(&dev->intf->dev, "Starting warmup...\n");
 
-	mutex_lock(&dev->lock);
+	/* Run bulk I/O after probe has returned and the xHCI endpoint is ready. */
+	msleep(100);
+	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
+		return;
 
-	while (!infnoise_health_ok(&dev->health) &&
+	mutex_lock(&dev->lock);
+	ret = infnoise_prime_ftdi(dev);
+
+	while (!ret && !infnoise_health_ok(&dev->health) &&
 	       rounds < INFNOISE_WARMUP_ROUNDS &&
 	       test_bit(INFNOISE_PRESENT, &dev->flags)) {
-		infnoise_read_data(dev, discard, sizeof(discard), true);
+		ret = infnoise_read_data(dev, discard, sizeof(discard), true);
+		if (ret < 0)
+			break;
 		rounds++;
 	}
 
@@ -627,7 +609,10 @@ static void infnoise_warmup_work(struct work_struct *work)
 		return;
 	}
 
-	if (rounds >= INFNOISE_WARMUP_ROUNDS) {
+	if (ret < 0) {
+		dev_err(&dev->intf->dev, "Warmup stopped after USB error: %d\n", ret);
+		set_bit(INFNOISE_HEALTH_FAIL, &dev->flags);
+	} else if (rounds >= INFNOISE_WARMUP_ROUNDS) {
 		dev_err(&dev->intf->dev,
 			"Warmup failed after %u rounds\n", rounds);
 		set_bit(INFNOISE_HEALTH_FAIL, &dev->flags);
@@ -919,11 +904,6 @@ static int infnoise_probe(struct usb_interface *intf,
 
 	/* Configure FTDI */
 	ret = infnoise_configure_ftdi(dev);
-	if (ret)
-		goto err_health;
-
-	/* Test transfer to prime the device */
-	ret = infnoise_test_transfer(dev);
 	if (ret)
 		goto err_health;
 

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -85,16 +85,21 @@ static int infnoise_configure_ftdi(struct infnoise_device *dev)
 		return ret;
 	}
 
-	/* Match libftdi: configure its default baudrate before the target rate. */
-	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, FTDI_BAUDRATE_9600,
-			   FTDI_INDEX_BAUDRATE_A);
+	/* Set latency timer to 1ms for faster response */
+	ret = ftdi_control(dev, FTDI_SIO_SET_LATENCY_TIMER, 1,
+			   FTDI_INDEX_INTERFACE_A);
 	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Failed to set default baud rate: %d\n", ret);
+		dev_err(&dev->intf->dev, "Failed to set latency timer: %d\n", ret);
 		return ret;
 	}
 
-	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, FTDI_BAUDRATE_30000,
-			   FTDI_INDEX_BAUDRATE_A);
+	/*
+	 * Set baud rate to 30000
+	 * FTDI baud rate encoding: value = 3000000 / baud
+	 * For 30000 baud: value = 100 = 0x0064
+	 */
+	ret = ftdi_control(dev, FTDI_SIO_SET_BAUDRATE, 0x0064,
+			   FTDI_INDEX_INTERFACE_A);
 	if (ret < 0) {
 		dev_err(&dev->intf->dev, "Failed to set baud rate: %d\n", ret);
 		return ret;
@@ -113,10 +118,72 @@ static int infnoise_configure_ftdi(struct infnoise_device *dev)
 		return ret;
 	}
 
-	/* The USB interface has just been bound; let SYNCBB settle before its
-	 * first bulk URB is queued from probe context. */
+	/* Purge RX buffer */
+	ret = ftdi_control(dev, FTDI_SIO_RESET, FTDI_SIO_RESET_PURGE_RX,
+			   FTDI_INDEX_INTERFACE_A);
+	if (ret < 0) {
+		dev_err(&dev->intf->dev, "Failed to purge RX: %d\n", ret);
+		return ret;
+	}
+
+	/* Purge TX buffer */
+	ret = ftdi_control(dev, FTDI_SIO_RESET, FTDI_SIO_RESET_PURGE_TX,
+			   FTDI_INDEX_INTERFACE_A);
+	if (ret < 0) {
+		dev_err(&dev->intf->dev, "Failed to purge TX: %d\n", ret);
+		return ret;
+	}
+
+	/* Give the device time to settle after configuration */
 	msleep(50);
 
+	return 0;
+}
+
+/*
+ * Test USB transfer to verify device is working
+ * Similar to what libftdi does during initialization
+ */
+static int infnoise_test_transfer(struct infnoise_device *dev)
+{
+	u8 *test_buf;
+	int ret, actual;
+
+	/* Allocate DMA-capable buffer */
+	test_buf = kmalloc(64, GFP_KERNEL);
+	if (!test_buf)
+		return -ENOMEM;
+
+	memset(test_buf, 0, 64);
+
+	/* Clear any halt condition on endpoints */
+	usb_clear_halt(dev->udev, usb_sndbulkpipe(dev->udev, dev->bulk_out_ep));
+	usb_clear_halt(dev->udev, usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep));
+
+	/* Test write */
+	ret = usb_bulk_msg(dev->udev,
+			   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
+			   test_buf, 64,
+			   &actual, INFNOISE_USB_TIMEOUT);
+	if (ret < 0) {
+		dev_err(&dev->intf->dev, "Test write failed: %d\n", ret);
+		kfree(test_buf);
+		return ret;
+	}
+
+	/* Test read */
+	ret = usb_bulk_msg(dev->udev,
+			   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
+			   test_buf, 64,
+			   &actual, INFNOISE_USB_TIMEOUT);
+	if (ret < 0) {
+		dev_err(&dev->intf->dev, "Test read failed: %d\n", ret);
+		kfree(test_buf);
+		return ret;
+	}
+
+	dev_info(&dev->intf->dev, "Test transfer OK (%d bytes)\n", actual);
+	kfree(test_buf);
 	return 0;
 }
 
@@ -230,110 +297,42 @@ static int infnoise_extract_bytes(struct infnoise_device *dev, u8 *bytes,
 	return infnoise_health_get_entropy(&dev->health);
 }
 
-/* Retry transient host-controller backpressure for a bounded interval. */
-static int infnoise_write_clocks(struct infnoise_device *dev, const u8 *clocks,
-					 size_t length)
-{
-	unsigned long deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
-	int actual;
-	int ret;
-
-	for (;;) {
-		ret = usb_bulk_msg(dev->udev,
-				   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
-				   (void *)clocks, length, &actual,
-				   INFNOISE_USB_TIMEOUT);
-		if (ret != -EAGAIN && !(ret == 0 && actual == 0))
-			break;
-		if (time_after_eq(jiffies, deadline))
-			return -ETIMEDOUT;
-		usleep_range(1000, 2000);
-	}
-
-	if (ret < 0)
-		return ret;
-	if (actual != length)
-		return -EIO;
-
-	return 0;
-}
-
 /*
- * Read FTDI packets until the requested number of sample bytes is available.
- * A bulk transfer can contain several 64-byte FTDI packets; remove the two
- * status bytes at the beginning of each packet before consuming samples.
+ * Strip FTDI modem status bytes from USB data
+ *
+ * FTDI sends data in 64-byte packets: 2 status bytes + 62 data bytes.
+ * This function extracts just the data bytes.
  */
-static int infnoise_read_samples(struct infnoise_device *dev, int target,
-				 int *data_bytes, unsigned long deadline)
+static int infnoise_strip_ftdi_status(struct infnoise_device *dev,
+				      int usb_bytes)
 {
-	int ret;
-	int actual;
-
-	while (*data_bytes < target) {
-		u8 *pkt = dev->usb_buf;
-		int offset;
-
-		ret = usb_bulk_msg(dev->udev,
-				   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
-				   pkt, INFNOISE_USB_READ_SIZE, &actual,
-				   INFNOISE_USB_TIMEOUT);
-		/* The host controller can transiently reject an URB with -EAGAIN. */
-		if (ret == -ETIMEDOUT || ret == -EAGAIN ||
-		    (ret == 0 && actual == 0)) {
-			if (time_after_eq(jiffies, deadline))
-				return -ETIMEDOUT;
-			usleep_range(100, 200);
-			continue;
-		}
-		if (ret < 0) {
-			if (infnoise_debug)
-				dev_dbg(&dev->intf->dev, "USB read failed: %d\n", ret);
-			return ret;
-		}
-
-		for (offset = 0; offset < actual && *data_bytes < target;) {
-			int packet_len = min(FTDI_PACKET_SIZE, actual - offset);
-			int payload;
-
-			if (packet_len > FTDI_STATUS_SIZE) {
-				payload = min(packet_len - FTDI_STATUS_SIZE,
-					      target - *data_bytes);
-				memcpy(dev->read_buf + *data_bytes,
-				       pkt + offset + FTDI_STATUS_SIZE, payload);
-				*data_bytes += payload;
-			}
-			offset += packet_len;
-		}
-	}
-
-	return 0;
-}
-
-/*
- * libftdi verifies a newly configured interface with a 64-byte synchronous
- * bit-bang exchange. A USB short packet contains FTDI status bytes, so read
- * all 64 sample bytes before considering the exchange complete.
- */
-static int infnoise_prime_ftdi(struct infnoise_device *dev)
-{
+	int packets = usb_bytes / FTDI_PACKET_SIZE;
+	int leftover = usb_bytes % FTDI_PACKET_SIZE;
 	int data_bytes = 0;
-	int ret;
-	unsigned long deadline;
+	int i;
 
-	/* read_buf is heap allocated and therefore valid for USB DMA. */
-	memset(dev->read_buf, 0, FTDI_PACKET_SIZE);
-	ret = infnoise_write_clocks(dev, dev->read_buf, FTDI_PACKET_SIZE);
-	if (ret) {
-		dev_err(&dev->intf->dev, "Initial FTDI write failed: %d\n", ret);
-		return ret;
+	for (i = 0; i < packets; i++) {
+		u8 *src = dev->usb_buf + i * FTDI_PACKET_SIZE + FTDI_STATUS_SIZE;
+		int copy_len = min(FTDI_DATA_PER_PACKET,
+				   INFNOISE_BUFLEN - data_bytes);
+
+		if (copy_len > 0) {
+			memcpy(dev->read_buf + data_bytes, src, copy_len);
+			data_bytes += copy_len;
+		}
 	}
 
-	deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
-	ret = infnoise_read_samples(dev, FTDI_PACKET_SIZE, &data_bytes, deadline);
-	if (ret)
-		dev_err(&dev->intf->dev, "Initial FTDI read failed: %d\n", ret);
+	/* Handle partial packet at end if any */
+	if (leftover > FTDI_STATUS_SIZE && data_bytes < INFNOISE_BUFLEN) {
+		int copy_len = min(leftover - FTDI_STATUS_SIZE,
+				   INFNOISE_BUFLEN - data_bytes);
+		u8 *src = dev->usb_buf + packets * FTDI_PACKET_SIZE + FTDI_STATUS_SIZE;
 
-	return ret;
+		memcpy(dev->read_buf + data_bytes, src, copy_len);
+		data_bytes += copy_len;
+	}
+
+	return data_bytes;
 }
 
 /*
@@ -345,24 +344,66 @@ static int infnoise_prime_ftdi(struct infnoise_device *dev)
 static int infnoise_usb_transfer_once(struct infnoise_device *dev)
 {
 	int ret;
-	int data_bytes = 0;
-	unsigned long deadline;
+	int actual;
+	int total_read = 0;
+	int data_bytes;
 
-	/*
-	 * SYNCBB returns one sample for each clock byte. Match the userspace
-	 * driver by queueing the complete 512-byte clock batch before reading.
-	 */
-	ret = infnoise_write_clocks(dev, dev->clock_buf, INFNOISE_BUFLEN);
-	if (ret) {
+	/* Write clock pattern */
+	ret = usb_bulk_msg(dev->udev,
+			   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
+			   dev->clock_buf, INFNOISE_BUFLEN,
+			   &actual, INFNOISE_USB_TIMEOUT);
+	if (ret < 0) {
 		if (infnoise_debug)
 			dev_dbg(&dev->intf->dev, "USB write failed: %d\n", ret);
 		return ret;
 	}
 
-	deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
-	ret = infnoise_read_samples(dev, INFNOISE_BUFLEN, &data_bytes, deadline);
-	if (ret)
-		return ret;
+	if (actual != INFNOISE_BUFLEN) {
+		dev_err(&dev->intf->dev, "Short write: %d/%d\n",
+			actual, INFNOISE_BUFLEN);
+		return -EIO;
+	}
+
+	/*
+	 * Read samples - FTDI returns data in 64-byte packets with 2 status
+	 * bytes per packet. We need to read until we have enough data bytes.
+	 */
+	while (total_read < INFNOISE_USB_READ_SIZE) {
+		int remaining = INFNOISE_USB_READ_SIZE - total_read;
+
+		ret = usb_bulk_msg(dev->udev,
+				   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
+				   dev->usb_buf + total_read, remaining,
+				   &actual, INFNOISE_USB_TIMEOUT);
+		if (ret < 0) {
+			if (infnoise_debug)
+				dev_dbg(&dev->intf->dev, "USB read failed: %d\n", ret);
+			return ret;
+		}
+
+		if (actual == 0) {
+			if (infnoise_debug)
+				dev_dbg(&dev->intf->dev, "USB read timeout, got %d/%d\n",
+					total_read, INFNOISE_USB_READ_SIZE);
+			return -ETIMEDOUT;
+		}
+
+		total_read += actual;
+
+		if (infnoise_debug && total_read < INFNOISE_USB_READ_SIZE)
+			dev_dbg(&dev->intf->dev, "Partial read: %d/%d, continuing\n",
+				total_read, INFNOISE_USB_READ_SIZE);
+	}
+
+	/* Strip FTDI status bytes to get actual data */
+	data_bytes = infnoise_strip_ftdi_status(dev, total_read);
+
+	if (data_bytes < INFNOISE_BUFLEN) {
+		dev_err(&dev->intf->dev, "Short data: %d/%d bytes\n",
+			data_bytes, INFNOISE_BUFLEN);
+		return -EIO;
+	}
 
 	/* Extract entropy bits */
 	return infnoise_extract_bytes(dev, dev->out_buf, INFNOISE_BYTES_OUT,
@@ -422,20 +463,6 @@ static int infnoise_usb_transfer(struct infnoise_device *dev)
 				dev_dbg(&dev->intf->dev,
 					"Non-recoverable error: %d\n", ret);
 			return ret;
-		}
-
-		/* Discard any partial batch before issuing a new set of clocks. */
-		if (retry + 1 < INFNOISE_MAX_RETRIES) {
-			int purge_ret;
-
-			purge_ret = ftdi_control(dev, FTDI_SIO_RESET,
-						 FTDI_SIO_RESET_PURGE_RX,
-						 FTDI_INDEX_INTERFACE_A);
-			if (purge_ret < 0) {
-				dev_warn(&dev->intf->dev,
-					 "Failed to purge RX before retry: %d\n", purge_ret);
-				return purge_ret;
-			}
 		}
 
 		/* Attempt recovery if we've hit the threshold */
@@ -581,24 +608,15 @@ static void infnoise_warmup_work(struct work_struct *work)
 						   warmup_work);
 	unsigned int rounds = 0;
 	u8 discard[64];
-	int ret = 0;
 
 	dev_info(&dev->intf->dev, "Starting warmup...\n");
 
-	/* Run bulk I/O after probe has returned and the xHCI endpoint is ready. */
-	msleep(100);
-	if (!test_bit(INFNOISE_PRESENT, &dev->flags))
-		return;
-
 	mutex_lock(&dev->lock);
-	ret = infnoise_prime_ftdi(dev);
 
-	while (!ret && !infnoise_health_ok(&dev->health) &&
+	while (!infnoise_health_ok(&dev->health) &&
 	       rounds < INFNOISE_WARMUP_ROUNDS &&
 	       test_bit(INFNOISE_PRESENT, &dev->flags)) {
-		ret = infnoise_read_data(dev, discard, sizeof(discard), true);
-		if (ret < 0)
-			break;
+		infnoise_read_data(dev, discard, sizeof(discard), true);
 		rounds++;
 	}
 
@@ -609,10 +627,7 @@ static void infnoise_warmup_work(struct work_struct *work)
 		return;
 	}
 
-	if (ret < 0) {
-		dev_err(&dev->intf->dev, "Warmup stopped after USB error: %d\n", ret);
-		set_bit(INFNOISE_HEALTH_FAIL, &dev->flags);
-	} else if (rounds >= INFNOISE_WARMUP_ROUNDS) {
+	if (rounds >= INFNOISE_WARMUP_ROUNDS) {
 		dev_err(&dev->intf->dev,
 			"Warmup failed after %u rounds\n", rounds);
 		set_bit(INFNOISE_HEALTH_FAIL, &dev->flags);
@@ -904,6 +919,11 @@ static int infnoise_probe(struct usb_interface *intf,
 
 	/* Configure FTDI */
 	ret = infnoise_configure_ftdi(dev);
+	if (ret)
+		goto err_health;
+
+	/* Test transfer to prime the device */
+	ret = infnoise_test_transfer(dev);
 	if (ret)
 		goto err_health;
 

--- a/software/kernel/infnoise_main.c
+++ b/software/kernel/infnoise_main.c
@@ -297,42 +297,82 @@ static int infnoise_extract_bytes(struct infnoise_device *dev, u8 *bytes,
 	return infnoise_health_get_entropy(&dev->health);
 }
 
-/*
- * Strip FTDI modem status bytes from USB data
- *
- * FTDI sends data in 64-byte packets: 2 status bytes + 62 data bytes.
- * This function extracts just the data bytes.
- */
-static int infnoise_strip_ftdi_status(struct infnoise_device *dev,
-				      int usb_bytes)
+/* Retry transient host-controller backpressure for a bounded interval. */
+static int infnoise_write_clocks(struct infnoise_device *dev, const u8 *clocks,
+				 size_t length)
 {
-	int packets = usb_bytes / FTDI_PACKET_SIZE;
-	int leftover = usb_bytes % FTDI_PACKET_SIZE;
-	int data_bytes = 0;
-	int i;
+	unsigned long deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
+	int actual;
+	int ret;
 
-	for (i = 0; i < packets; i++) {
-		u8 *src = dev->usb_buf + i * FTDI_PACKET_SIZE + FTDI_STATUS_SIZE;
-		int copy_len = min(FTDI_DATA_PER_PACKET,
-				   INFNOISE_BUFLEN - data_bytes);
+	for (;;) {
+		ret = usb_bulk_msg(dev->udev,
+				   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
+				   (void *)clocks, length, &actual,
+				   INFNOISE_USB_TIMEOUT);
+		if (ret != -EAGAIN && !(ret == 0 && actual == 0))
+			break;
+		if (time_after_eq(jiffies, deadline))
+			return -ETIMEDOUT;
+		usleep_range(1000, 2000);
+	}
 
-		if (copy_len > 0) {
-			memcpy(dev->read_buf + data_bytes, src, copy_len);
-			data_bytes += copy_len;
+	if (ret < 0)
+		return ret;
+	if (actual != length)
+		return -EIO;
+
+	return 0;
+}
+
+/*
+ * Read FTDI packets until the requested number of sample bytes is available.
+ * A bulk transfer can contain several 64-byte FTDI packets; remove the two
+ * status bytes at the beginning of each packet before consuming samples.
+ */
+static int infnoise_read_samples(struct infnoise_device *dev, int target,
+				 int *data_bytes, unsigned long deadline)
+{
+	int ret;
+	int actual;
+
+	while (*data_bytes < target) {
+		u8 *pkt = dev->usb_buf;
+		int offset;
+
+		ret = usb_bulk_msg(dev->udev,
+				   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
+				   pkt, INFNOISE_USB_READ_SIZE, &actual,
+				   INFNOISE_USB_TIMEOUT);
+		if (ret == -ETIMEDOUT || ret == -EAGAIN ||
+		    (ret == 0 && actual == 0)) {
+			if (time_after_eq(jiffies, deadline))
+				return -ETIMEDOUT;
+			usleep_range(100, 200);
+			continue;
+		}
+		if (ret < 0) {
+			if (infnoise_debug)
+				dev_dbg(&dev->intf->dev, "USB read failed: %d\n", ret);
+			return ret;
+		}
+
+		for (offset = 0; offset < actual && *data_bytes < target;) {
+			int packet_len = min(FTDI_PACKET_SIZE, actual - offset);
+			int payload;
+
+			if (packet_len > FTDI_STATUS_SIZE) {
+				payload = min(packet_len - FTDI_STATUS_SIZE,
+					      target - *data_bytes);
+				memcpy(dev->read_buf + *data_bytes,
+				       pkt + offset + FTDI_STATUS_SIZE, payload);
+				*data_bytes += payload;
+			}
+			offset += packet_len;
 		}
 	}
 
-	/* Handle partial packet at end if any */
-	if (leftover > FTDI_STATUS_SIZE && data_bytes < INFNOISE_BUFLEN) {
-		int copy_len = min(leftover - FTDI_STATUS_SIZE,
-				   INFNOISE_BUFLEN - data_bytes);
-		u8 *src = dev->usb_buf + packets * FTDI_PACKET_SIZE + FTDI_STATUS_SIZE;
-
-		memcpy(dev->read_buf + data_bytes, src, copy_len);
-		data_bytes += copy_len;
-	}
-
-	return data_bytes;
+	return 0;
 }
 
 /*
@@ -344,66 +384,20 @@ static int infnoise_strip_ftdi_status(struct infnoise_device *dev,
 static int infnoise_usb_transfer_once(struct infnoise_device *dev)
 {
 	int ret;
-	int actual;
-	int total_read = 0;
-	int data_bytes;
+	int data_bytes = 0;
+	unsigned long deadline;
 
-	/* Write clock pattern */
-	ret = usb_bulk_msg(dev->udev,
-			   usb_sndbulkpipe(dev->udev, dev->bulk_out_ep),
-			   dev->clock_buf, INFNOISE_BUFLEN,
-			   &actual, INFNOISE_USB_TIMEOUT);
-	if (ret < 0) {
+	ret = infnoise_write_clocks(dev, dev->clock_buf, INFNOISE_BUFLEN);
+	if (ret) {
 		if (infnoise_debug)
 			dev_dbg(&dev->intf->dev, "USB write failed: %d\n", ret);
 		return ret;
 	}
 
-	if (actual != INFNOISE_BUFLEN) {
-		dev_err(&dev->intf->dev, "Short write: %d/%d\n",
-			actual, INFNOISE_BUFLEN);
-		return -EIO;
-	}
-
-	/*
-	 * Read samples - FTDI returns data in 64-byte packets with 2 status
-	 * bytes per packet. We need to read until we have enough data bytes.
-	 */
-	while (total_read < INFNOISE_USB_READ_SIZE) {
-		int remaining = INFNOISE_USB_READ_SIZE - total_read;
-
-		ret = usb_bulk_msg(dev->udev,
-				   usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
-				   dev->usb_buf + total_read, remaining,
-				   &actual, INFNOISE_USB_TIMEOUT);
-		if (ret < 0) {
-			if (infnoise_debug)
-				dev_dbg(&dev->intf->dev, "USB read failed: %d\n", ret);
-			return ret;
-		}
-
-		if (actual == 0) {
-			if (infnoise_debug)
-				dev_dbg(&dev->intf->dev, "USB read timeout, got %d/%d\n",
-					total_read, INFNOISE_USB_READ_SIZE);
-			return -ETIMEDOUT;
-		}
-
-		total_read += actual;
-
-		if (infnoise_debug && total_read < INFNOISE_USB_READ_SIZE)
-			dev_dbg(&dev->intf->dev, "Partial read: %d/%d, continuing\n",
-				total_read, INFNOISE_USB_READ_SIZE);
-	}
-
-	/* Strip FTDI status bytes to get actual data */
-	data_bytes = infnoise_strip_ftdi_status(dev, total_read);
-
-	if (data_bytes < INFNOISE_BUFLEN) {
-		dev_err(&dev->intf->dev, "Short data: %d/%d bytes\n",
-			data_bytes, INFNOISE_BUFLEN);
-		return -EIO;
-	}
+	deadline = jiffies + msecs_to_jiffies(INFNOISE_USB_TIMEOUT);
+	ret = infnoise_read_samples(dev, INFNOISE_BUFLEN, &data_bytes, deadline);
+	if (ret)
+		return ret;
 
 	/* Extract entropy bits */
 	return infnoise_extract_bytes(dev, dev->out_buf, INFNOISE_BYTES_OUT,

--- a/software/kernel/test_infnoise.c
+++ b/software/kernel/test_infnoise.c
@@ -30,8 +30,6 @@
 #include <sys/wait.h>
 #include <stdint.h>
 #include <time.h>
-#include <glob.h>
-#include <limits.h>
 
 /* Must match kernel header exactly */
 struct infnoise_stats {
@@ -53,7 +51,6 @@ struct infnoise_stats {
 #define INFNOISE_GET_ENTROPY	_IOR(INFNOISE_IOC_MAGIC, 3, uint32_t)
 
 static int passed = 0, failed = 0, skipped = 0;
-static char device_path[PATH_MAX];
 
 #define TEST(name) printf("  %-50s ", name)
 #define PASS() do { printf("\033[32mPASS\033[0m\n"); passed++; } while(0)
@@ -112,7 +109,7 @@ static void test_hwrng_read(void)
 static void test_nonblock(void)
 {
 	TEST("O_NONBLOCK returns EAGAIN or data");
-	int fd = open(device_path, O_RDONLY | O_NONBLOCK);
+	int fd = open("/dev/infnoise0", O_RDONLY | O_NONBLOCK);
 	if (fd < 0) {
 		FAIL(strerror(errno));
 		return;
@@ -157,7 +154,7 @@ static void test_interruptible(void)
 
 	if (pid == 0) {
 		signal(SIGUSR1, child_handler);
-		int fd = open(device_path, O_RDONLY);
+		int fd = open("/dev/infnoise0", O_RDONLY);
 		if (fd < 0) _exit(2);
 
 		uint8_t buf[64];
@@ -325,7 +322,7 @@ static void test_open_close_reopen(void)
 	TEST("open/close/reopen 5 times");
 
 	for (int i = 0; i < 5; i++) {
-		int fd = open(device_path, O_RDONLY);
+		int fd = open("/dev/infnoise0", O_RDONLY);
 		if (fd < 0) {
 			char msg[64];
 			snprintf(msg, sizeof(msg), "open %d: %s", i, strerror(errno));
@@ -348,53 +345,16 @@ static void test_open_close_reopen(void)
 
 /* ── Main ───────────────────────────────────────────────── */
 
-static int find_device_path(void)
-{
-	glob_t matches;
-	int path_len;
-	int ret;
-
-	/* Prefer the node created by usb_register_dev(), then udev aliases. */
-	ret = glob("/dev/infnoise[0-9]*", 0, NULL, &matches);
-	if (ret != 0)
-		ret = glob("/dev/infnoise-*", 0, NULL, &matches);
-	if (ret != 0)
-		return -1;
-
-	path_len = snprintf(device_path, sizeof(device_path), "%s",
-			    matches.gl_pathv[0]);
-	if (path_len < 0 || path_len >= (int)sizeof(device_path)) {
-		globfree(&matches);
-		return -1;
-	}
-
-	globfree(&matches);
-	return 0;
-}
-
-int main(int argc, char **argv)
+int main(void)
 {
 	int fd;
-	int path_len;
 
 	printf("\nInfinite Noise TRNG Kernel Module — Test Harness\n");
 	printf("=================================================\n\n");
 
-	if (argc > 1) {
-		path_len = snprintf(device_path, sizeof(device_path), "%s", argv[1]);
-		if (path_len < 0 || path_len >= (int)sizeof(device_path)) {
-			fprintf(stderr, "Device path is too long\n");
-			return 1;
-		}
-	} else if (find_device_path() < 0) {
-		fprintf(stderr, "Cannot find /dev/infnoise-*\n");
-		fprintf(stderr, "Is the module loaded? Try: sudo insmod infnoise.ko\n");
-		return 1;
-	}
-
-	fd = open(device_path, O_RDONLY);
+	fd = open("/dev/infnoise0", O_RDONLY);
 	if (fd < 0) {
-		fprintf(stderr, "Cannot open %s: %s\n", device_path, strerror(errno));
+		fprintf(stderr, "Cannot open /dev/infnoise0: %s\n", strerror(errno));
 		fprintf(stderr, "Is the module loaded? Try: sudo insmod infnoise.ko\n");
 		return 1;
 	}

--- a/software/kernel/test_infnoise.c
+++ b/software/kernel/test_infnoise.c
@@ -30,6 +30,8 @@
 #include <sys/wait.h>
 #include <stdint.h>
 #include <time.h>
+#include <glob.h>
+#include <limits.h>
 
 /* Must match kernel header exactly */
 struct infnoise_stats {
@@ -51,6 +53,7 @@ struct infnoise_stats {
 #define INFNOISE_GET_ENTROPY	_IOR(INFNOISE_IOC_MAGIC, 3, uint32_t)
 
 static int passed = 0, failed = 0, skipped = 0;
+static char device_path[PATH_MAX];
 
 #define TEST(name) printf("  %-50s ", name)
 #define PASS() do { printf("\033[32mPASS\033[0m\n"); passed++; } while(0)
@@ -109,7 +112,7 @@ static void test_hwrng_read(void)
 static void test_nonblock(void)
 {
 	TEST("O_NONBLOCK returns EAGAIN or data");
-	int fd = open("/dev/infnoise0", O_RDONLY | O_NONBLOCK);
+	int fd = open(device_path, O_RDONLY | O_NONBLOCK);
 	if (fd < 0) {
 		FAIL(strerror(errno));
 		return;
@@ -154,7 +157,7 @@ static void test_interruptible(void)
 
 	if (pid == 0) {
 		signal(SIGUSR1, child_handler);
-		int fd = open("/dev/infnoise0", O_RDONLY);
+		int fd = open(device_path, O_RDONLY);
 		if (fd < 0) _exit(2);
 
 		uint8_t buf[64];
@@ -322,7 +325,7 @@ static void test_open_close_reopen(void)
 	TEST("open/close/reopen 5 times");
 
 	for (int i = 0; i < 5; i++) {
-		int fd = open("/dev/infnoise0", O_RDONLY);
+		int fd = open(device_path, O_RDONLY);
 		if (fd < 0) {
 			char msg[64];
 			snprintf(msg, sizeof(msg), "open %d: %s", i, strerror(errno));
@@ -345,16 +348,53 @@ static void test_open_close_reopen(void)
 
 /* ── Main ───────────────────────────────────────────────── */
 
-int main(void)
+static int find_device_path(void)
+{
+	glob_t matches;
+	int path_len;
+	int ret;
+
+	/* Prefer the node created by usb_register_dev(), then udev aliases. */
+	ret = glob("/dev/infnoise[0-9]*", 0, NULL, &matches);
+	if (ret != 0)
+		ret = glob("/dev/infnoise-*", 0, NULL, &matches);
+	if (ret != 0)
+		return -1;
+
+	path_len = snprintf(device_path, sizeof(device_path), "%s",
+			    matches.gl_pathv[0]);
+	if (path_len < 0 || path_len >= (int)sizeof(device_path)) {
+		globfree(&matches);
+		return -1;
+	}
+
+	globfree(&matches);
+	return 0;
+}
+
+int main(int argc, char **argv)
 {
 	int fd;
+	int path_len;
 
 	printf("\nInfinite Noise TRNG Kernel Module — Test Harness\n");
 	printf("=================================================\n\n");
 
-	fd = open("/dev/infnoise0", O_RDONLY);
+	if (argc > 1) {
+		path_len = snprintf(device_path, sizeof(device_path), "%s", argv[1]);
+		if (path_len < 0 || path_len >= (int)sizeof(device_path)) {
+			fprintf(stderr, "Device path is too long\n");
+			return 1;
+		}
+	} else if (find_device_path() < 0) {
+		fprintf(stderr, "Cannot find /dev/infnoise-*\n");
+		fprintf(stderr, "Is the module loaded? Try: sudo insmod infnoise.ko\n");
+		return 1;
+	}
+
+	fd = open(device_path, O_RDONLY);
 	if (fd < 0) {
-		fprintf(stderr, "Cannot open /dev/infnoise0: %s\n", strerror(errno));
+		fprintf(stderr, "Cannot open %s: %s\n", device_path, strerror(errno));
 		fprintf(stderr, "Is the module loaded? Try: sudo insmod infnoise.ko\n");
 		return 1;
 	}


### PR DESCRIPTION
## Problem

The kernel driver intermittently makes a working Infinite Noise device
unusable during warmup.

The device is detected and registered successfully, but warmup can report
false `stuck-at-0` health failures and eventually fail reads with `-EIO`:

```text
Test transfer OK (23 bytes)
infnoise: stuck-at-0 fault detected (21 consecutive 0s)
Health check failed!
Transfer failed after 3 retries, last error: -5
```

The same device produces stable output in the userspace libftdi-based tool,
including normal entropy estimates and an approximately balanced bit
distribution. This isolates the failure to the kernel driver's FT240X setup
and input-stream handling.

## Root Cause

FT240X bulk-IN data includes two modem-status bytes at the beginning of every
USB packet. The driver accumulated short and partial bulk reads into one
buffer, then inferred status-byte boundaries from the final aggregate length.
Status bytes from a subsequent short read could therefore be consumed as
comparator samples, corrupting the data passed to the health checker.

Additionally, the probe-time test exchange wrote 64 all-zero clock bytes but
accepted a short read as success. Its uncollected samples remained in the
device FIFO and were consumed by early warmup rounds, producing false runs of
zero bits.

The FTDI control-transfer sequence also differed from the working libftdi
userspace driver, as verified with usbmon.

## Fix

- Match the FT240X control-transfer sequence observed from the libftdi driver,
  including the baud-rate request interface index.
- Read bulk-IN data in 4 KiB chunks and remove FTDI status bytes for every
  packet returned by each bulk transfer.
- Require the initial synchronous bit-bang exchange to collect all expected
  samples instead of accepting a short read as success.
- Move the initial exchange from probe context into the warmup worker.
- Purge stale RX data before retrying a failed transfer and stop warmup after
  an unrecoverable error.
- Make the kernel test harness discover both native `infnoise<N>` nodes and
  udev aliases(just for mine).

## Testing

- `make -C software/kernel clean modules test_infnoise`
- Hardware test harness: 11 passed, 0 failed, 0 skipped.
- Verified successful warmup and entropy generation on the affected device.
- Verified character-device and hwrng reads, non-blocking I/O, signal
  interruption, ioctls, and repeated open/close cycles.
- Tested on a self-built FT240X device (custom VID/PID 0x66CC:0xFFFF);
  the fix is hardware-agnostic and applies to stock devices as well.

## Follow-up

`INFNOISE_HEALTH_FAIL` remains a permanent latch after a genuine health
failure. Recovery semantics for that state can be considered separately.